### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete multi-character sanitization

### DIFF
--- a/src/lib/security/ai-sanitization.ts
+++ b/src/lib/security/ai-sanitization.ts
@@ -108,7 +108,15 @@ export function sanitizeAIInput(input: string): SanitizationResult {
   processed = processed
     .replace(/```/g, "'''") // Prevent code block manipulation
     .replace(/#+\s/g, '') // Remove markdown headers
-    .replace(/<\/?[a-z][^>]*>/gi, '') // Remove HTML-like tags
+
+  // Iteratively remove HTML-like tags and any script-like remnants
+  let previous: string
+  do {
+    previous = processed
+    processed = processed
+      .replace(/<\/?[a-z][^>]*>/gi, '') // Remove HTML-like tags
+      .replace(/<\/?\s*script\b[^>]*/gi, '') // Remove any remaining script-like starts
+  } while (processed !== previous)
 
   return { sanitized: processed, flagged: false }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/carterlasalle/staminatimer/security/code-scanning/17](https://github.com/carterlasalle/staminatimer/security/code-scanning/17)

In general, to fix incomplete multi-character sanitization you should either (a) use a well-tested sanitization library, or (b) ensure that your sanitization runs until it reaches a fixed point (no more changes), or (c) adjust the regex so that newly formed unsafe sequences cannot appear after one replacement. In this file, we’re already comfortable deleting *all* HTML-like tags, so we can safely strengthen the current approach without changing functional intent.

Best single fix, preserving behavior:

1. Keep using regex-based stripping of HTML-like tags, but **apply it repeatedly in a loop** until a pass produces no changes. This directly addresses the “multi-character reformation” problem.
2. Within that loop, also explicitly strip any `<script` or `</script` sequences to cover malformed or partially constructed script tags that might not match the generic HTML tag regex.
3. Do all of this inside `sanitizeAIInput` where `processed` is currently sanitized with the chained `.replace(...)` calls.
4. No new imports are needed; only modifications within `src/lib/security/ai-sanitization.ts` around the existing replacement logic on lines 107–112.

Concretely:
- Replace the current chained `.replace` expressions at lines 108–111 with:
  - A first pass to normalize code fences and headings (the existing ` ``` -> '''` and `#+\s` removals).
  - Then a `do { ... } while` loop that repeatedly strips HTML-like tags and any `<script`/`</script` substrings until `processed` stops changing.

This keeps the rest of the pipeline (length checks, entropy, etc.) intact while closing the specific incomplete-sanitization gap.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
