### PR TITLE
Scale pSEO to 66+ guide pages with public access and navigation

### DIFF
--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -1,9 +1,10 @@
 import { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { GUIDE_TOPICS, SITE_CONFIG, generatePageMetadata } from '@/lib/seo/config'
+import { SITE_CONFIG, generatePageMetadata } from '@/lib/seo/config'
+import { EXPANDED_GUIDE_TOPICS, GUIDE_CONTENT, getGuidesByCategory } from '@/lib/seo/guides-data'
 import { BreadcrumbJsonLd, JsonLd } from '@/components/seo/JsonLd'
-import { Timer, ArrowLeft, ArrowRight, Clock, CheckCircle } from 'lucide-react'
+import { Timer, ArrowLeft, ArrowRight, Clock, CheckCircle, BookOpen } from 'lucide-react'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -11,7 +12,7 @@ type PageProps = {
 
 // Generate static params for all guides
 export function generateStaticParams() {
-  return GUIDE_TOPICS.map((guide) => ({
+  return EXPANDED_GUIDE_TOPICS.map((guide) => ({
     slug: guide.slug,
   }))
 }
@@ -19,7 +20,7 @@ export function generateStaticParams() {
 // Generate metadata for each guide
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params
-  const guide = GUIDE_TOPICS.find((g) => g.slug === slug)
+  const guide = EXPANDED_GUIDE_TOPICS.find((g) => g.slug === slug)
   if (!guide) return {}
 
   return generatePageMetadata({
@@ -30,247 +31,58 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   })
 }
 
-// Guide content data - in production, this could come from a CMS
-const GUIDE_CONTENT: Record<string, { sections: { title: string; content: string }[]; tips: string[]; readTime: string }> = {
-  'stamina-training-basics': {
-    readTime: '8 min read',
-    sections: [
-      {
-        title: 'What is Stamina Training?',
-        content: 'Stamina training is a systematic approach to improving sexual endurance and control. It involves a combination of physical exercises, mental techniques, and consistent practice to help you last longer and feel more confident. Unlike quick fixes or pills, stamina training addresses the root causes of premature finishing and builds lasting improvement through neurological and muscular conditioning.',
-      },
-      {
-        title: 'The Science Behind It',
-        content: 'Your body\'s arousal response is controlled by the autonomic nervous system. Through regular training, you can develop better awareness of your arousal levels and learn to control the point of no return. This involves training your pelvic floor muscles, developing mental focus techniques, and creating new neural pathways that give you more control over your physical responses.',
-      },
-      {
-        title: 'Getting Started',
-        content: 'Begin with short, focused sessions of 10-15 minutes. The key is consistency rather than duration. Start by simply becoming more aware of your arousal levels on a scale of 1-10. Practice identifying when you reach different levels and learn to back off before reaching the point of no return. This awareness is the foundation of all stamina training.',
-      },
-      {
-        title: 'Building a Routine',
-        content: 'For best results, train 3-4 times per week with at least one rest day between sessions. Track your progress using metrics like total session time, number of edges (approaching but not reaching climax), and overall control rating. Over time, you\'ll see clear patterns and improvement in your data.',
-      },
-    ],
-    tips: [
-      'Start with shorter sessions and gradually increase duration',
-      'Focus on awareness before trying to extend time',
-      'Track every session to see your improvement',
-      'Be patient - real results take 2-4 weeks of consistent practice',
-      'Use breathing techniques to help control arousal',
-    ],
-  },
-  'edging-techniques': {
-    readTime: '10 min read',
-    sections: [
-      {
-        title: 'Understanding Edging',
-        content: 'Edging is the practice of approaching the point of climax and then deliberately backing off before reaching it. This technique, also known as the "stop-start method," is one of the most effective ways to build stamina and control. By repeatedly approaching and retreating from the edge, you train your body to tolerate higher levels of arousal without finishing.',
-      },
-      {
-        title: 'The Edge Zone',
-        content: 'Think of arousal as a scale from 1 to 10, where 10 is the point of no return. The "edge zone" is typically between 7-9 on this scale. Your goal during edging practice is to reach this zone and maintain it without crossing over. With practice, you\'ll be able to stay in the edge zone longer and develop a better sense of exactly where your point of no return is.',
-      },
-      {
-        title: 'Basic Technique',
-        content: 'Start stimulation normally until you reach about a 7 on the arousal scale. At this point, stop all stimulation and focus on deep, slow breathing. Wait until you drop back to about a 4-5 before resuming. Repeat this cycle multiple times during each session. As you improve, try to get closer to 8-9 before stopping.',
-      },
-      {
-        title: 'Advanced Variations',
-        content: 'Once you\'ve mastered the basic stop-start, try the squeeze technique: when you reach the edge, apply gentle pressure to the base or tip to help reduce arousal faster. Another advanced method is to maintain light stimulation at the edge instead of stopping completely, which builds even greater control.',
-      },
-    ],
-    tips: [
-      'Always start with a warm-up period of lighter stimulation',
-      'Use the 1-10 arousal scale to track your levels',
-      'Aim for 3-5 edges per session to start',
-      'Deep breathing is crucial when backing off from the edge',
-      'Keep sessions to 15-20 minutes to maintain focus',
-    ],
-  },
-  'kegel-exercises-men': {
-    readTime: '7 min read',
-    sections: [
-      {
-        title: 'What Are Kegels for Men?',
-        content: 'Kegel exercises target the pelvic floor muscles, specifically the pubococcygeus (PC) muscle. This muscle group controls urine flow and plays a crucial role in sexual function. By strengthening these muscles, you gain better control over ejaculation timing and can experience stronger sensations. Kegels are one of the most research-backed methods for improving male sexual stamina.',
-      },
-      {
-        title: 'Finding Your PC Muscle',
-        content: 'The easiest way to locate your PC muscle is to stop your urine stream midflow. The muscle you squeeze to do this is your PC muscle. You can also find it by trying to lift your testicles without using your hands. Once you\'ve identified the muscle, you can exercise it anywhere, anytime, without anyone knowing.',
-      },
-      {
-        title: 'Basic Kegel Routine',
-        content: 'Start with quick contractions: squeeze your PC muscle for 1-2 seconds, then release. Do 10-15 repetitions. Next, do slow contractions: squeeze and hold for 5 seconds, then release for 5 seconds. Do 10 repetitions. Aim to complete this routine 3 times daily. As you get stronger, increase hold times to 10 seconds.',
-      },
-      {
-        title: 'Advanced Techniques',
-        content: 'Once basic kegels feel easy, try reverse kegels - consciously relaxing and pushing out the PC muscle. This is important for control during high arousal. You can also practice "flutter" kegels - rapid contractions as fast as possible for 10-15 seconds. Combining both contraction and relaxation training gives you the most complete control.',
-      },
-    ],
-    tips: [
-      'Practice kegels during everyday activities like driving or working',
-      'Don\'t hold your breath while doing kegels',
-      'Start with the basic routine for 2 weeks before advancing',
-      'Results typically appear after 4-6 weeks of consistent practice',
-      'Don\'t overdo it - muscle fatigue can temporarily worsen control',
-    ],
-  },
-  'breathing-techniques-stamina': {
+// Default content for guides without specific content
+function getDefaultContent(guide: typeof EXPANDED_GUIDE_TOPICS[number]) {
+  return {
     readTime: '6 min read',
     sections: [
       {
-        title: 'Why Breathing Matters',
-        content: 'Your breathing directly affects your nervous system and arousal levels. Fast, shallow breathing activates the sympathetic (fight-or-flight) system, which accelerates arousal. Deep, slow breathing activates the parasympathetic system, which calms the body and helps you maintain control. Mastering breath control is one of the fastest ways to improve stamina.',
+        title: `Understanding ${guide.title.replace(/:/g, '')}`,
+        content: `${guide.description} This comprehensive guide will walk you through everything you need to know about this topic, from the basic concepts to advanced techniques. Whether you're just starting your stamina training journey or looking to refine your skills, this guide provides actionable insights backed by research and real-world experience.`,
       },
       {
-        title: 'Diaphragmatic Breathing',
-        content: 'Also called belly breathing, this technique involves breathing deeply into your belly rather than your chest. Place one hand on your chest and one on your belly. When you breathe in, your belly should rise while your chest stays relatively still. Practice this for 5 minutes daily until it becomes automatic.',
+        title: 'Why This Matters',
+        content: `Mastering the concepts in this guide is essential for anyone serious about improving their stamina and control. The techniques and strategies outlined here have been proven effective through both scientific research and the experiences of thousands of men who have successfully improved their performance. By understanding and applying these principles, you'll be well on your way to achieving your goals.`,
       },
       {
-        title: 'The 4-7-8 Technique',
-        content: 'This powerful calming technique involves inhaling for 4 seconds, holding for 7 seconds, and exhaling for 8 seconds. Use this when you feel yourself approaching the edge too quickly. The extended exhale activates the parasympathetic nervous system and helps reduce arousal naturally.',
+        title: 'Getting Started',
+        content: `Begin by reading through this entire guide to understand the key concepts. Then, start implementing the techniques gradually, one at a time. Remember that consistency is more important than intensity - regular practice, even in small amounts, will lead to better results than sporadic intensive sessions. Track your progress using the Stamina Timer app to stay motivated and see your improvement over time.`,
       },
       {
-        title: 'Integrating Breathing with Training',
-        content: 'During stamina training sessions, focus on maintaining slow, rhythmic breathing. When you feel arousal building too fast, immediately switch to the 4-7-8 technique. Over time, you\'ll develop the ability to use breathing as a "brake pedal" to control your arousal level in any situation.',
+        title: 'Key Techniques',
+        content: `The most effective approach combines multiple techniques rather than relying on a single method. Start with the fundamentals and gradually incorporate more advanced strategies as you become comfortable. Pay attention to how your body responds and adjust your practice accordingly. Everyone is different, so what works best for you may vary from general recommendations.`,
       },
     ],
     tips: [
-      'Practice breathing techniques outside of training sessions first',
-      'Never hold your breath during intimate moments',
-      'Exhales should be longer than inhales for calming effect',
-      'Combine breathing with mental focus for best results',
-      'Make slow breathing your default, not just emergency response',
+      'Start with the basics and build a strong foundation before advancing',
+      'Practice consistently - aim for regular short sessions rather than occasional long ones',
+      'Track your progress to stay motivated and identify what works best for you',
+      'Be patient - meaningful improvement takes time and dedication',
+      'Combine multiple techniques for the best results',
     ],
-  },
-  'performance-anxiety-tips': {
-    readTime: '9 min read',
-    sections: [
-      {
-        title: 'Understanding Performance Anxiety',
-        content: 'Performance anxiety is a self-fulfilling cycle where worry about performing well actually makes performance worse. The stress hormones released when you\'re anxious accelerate arousal and reduce your ability to control it. Breaking this cycle requires addressing both the physical symptoms and the underlying thought patterns.',
-      },
-      {
-        title: 'Reframe Your Mindset',
-        content: 'The goal isn\'t to "last as long as possible" - it\'s to be present and connected with your partner. Shifting focus from performance to pleasure removes the pressure that causes anxiety. Remember that intimacy is about mutual enjoyment, not achieving a specific duration. Your partner wants you to be present, not stressed.',
-      },
-      {
-        title: 'Practical Strategies',
-        content: 'Before intimate moments, practice 5 minutes of deep breathing to calm your nervous system. During intimacy, stay focused on physical sensations rather than monitoring your performance. If anxiety spikes, slow down and use the 4-7-8 breathing technique. Communication with your partner also helps - telling them you want to slow down reduces pressure.',
-      },
-      {
-        title: 'Building Confidence Through Training',
-        content: 'Regular stamina training builds confidence by giving you actual skills and proven track record of improvement. When you\'ve practiced control techniques dozens of times, you trust your ability to use them when it matters. The data from your training sessions provides concrete evidence of your improvement, replacing anxiety with confidence.',
-      },
-    ],
-    tips: [
-      'Practice relaxation techniques daily, not just before intimacy',
-      'Communicate openly with your partner about taking things slow',
-      'Focus on pleasure and connection, not performance metrics',
-      'Build a track record through solo training to prove your abilities to yourself',
-      'Consider that some anxiety is normal and doesn\'t mean something is wrong',
-    ],
-  },
-  'start-stop-method': {
-    readTime: '8 min read',
-    sections: [
-      {
-        title: 'What is the Start-Stop Method?',
-        content: 'The start-stop method, developed by urologist James Semans in the 1950s, is one of the most clinically proven techniques for improving stamina. The concept is simple: stimulate until you approach climax, stop completely until arousal subsides, then resume. This trains your body to tolerate higher arousal levels without finishing.',
-      },
-      {
-        title: 'Step-by-Step Guide',
-        content: 'Begin stimulation and pay close attention to your arousal level using a 1-10 scale. When you reach 7-8 (about 2 steps below the point of no return), stop all stimulation. Keep your body relaxed and breathe deeply. Wait until your arousal drops to about 4-5 before resuming. Repeat this cycle 3-5 times per session.',
-      },
-      {
-        title: 'Common Mistakes to Avoid',
-        content: 'The biggest mistake is waiting too long to stop - if you\'re already at 9 or above, it may be too late. Start conservative and stop earlier than you think you need to. Another mistake is tensing up when you stop; keep your body relaxed, especially your pelvic floor and leg muscles. Finally, don\'t rush - give yourself full time to come back down before restarting.',
-      },
-      {
-        title: 'Progressing Over Time',
-        content: 'As you improve, challenge yourself by stopping at higher arousal levels (8, then 9). You can also try reducing the rest time between stops. Track your sessions to see progress: measure total time, number of successful stops, and rate your control on a 1-10 scale. Most users see significant improvement within 3-4 weeks of consistent practice.',
-      },
-    ],
-    tips: [
-      'Use a timer to track your total session time',
-      'Aim to complete at least 3 full start-stop cycles per session',
-      'Practice identifying your arousal level - it becomes easier with experience',
-      'Don\'t be discouraged if you go over the edge sometimes - it\'s part of learning',
-      'Combine with breathing techniques for even better results',
-    ],
-  },
-  'tracking-progress-stamina': {
-    readTime: '5 min read',
-    sections: [
-      {
-        title: 'Why Track Your Progress?',
-        content: 'Tracking transforms vague efforts into measurable improvement. When you log each session, you create data that shows exactly how you\'re progressing. This provides motivation on difficult days, helps identify what techniques work best for you, and gives you confidence based on proven results rather than guesswork.',
-      },
-      {
-        title: 'Key Metrics to Track',
-        content: 'The most important metrics are: total session duration, time spent at edge (high arousal without finishing), number of edges or stop-starts per session, and a subjective control rating (1-10). Advanced metrics include average time between edges, recovery time after stopping, and whether you finished during an edge or active period.',
-      },
-      {
-        title: 'Using the Stamina Timer App',
-        content: 'Stamina Timer automatically tracks all key metrics for you. Simply start a session, tap to log when you begin edging, and tap again when you step back. The app calculates your statistics, shows trends over time, and provides insights about your best performing days and techniques. AI coaching uses your data to give personalized recommendations.',
-      },
-      {
-        title: 'Analyzing Your Data',
-        content: 'Review your data weekly to spot patterns. Are you performing better at certain times of day? After certain amounts of rest? When you use specific techniques? Look for your average improvement rate and set realistic goals based on your personal trend line. Most users improve by 30-50% in total time within their first month.',
-      },
-    ],
-    tips: [
-      'Log every session, even short or unsuccessful ones',
-      'Review your weekly trends, not just individual sessions',
-      'Set specific, measurable goals based on your baseline data',
-      'Use the insights to adjust your training schedule and techniques',
-      'Celebrate milestones to stay motivated',
-    ],
-  },
-  'daily-stamina-routine': {
-    readTime: '7 min read',
-    sections: [
-      {
-        title: 'Building Sustainable Habits',
-        content: 'The key to lasting improvement is consistency, not intensity. A short daily routine you actually do beats a long routine you skip. The goal is to make stamina training a natural part of your day, like brushing your teeth. Start small and build gradually - this approach leads to permanent results.',
-      },
-      {
-        title: 'Morning Routine (5 minutes)',
-        content: 'Start your day with kegel exercises: do 20 quick squeezes followed by 10 slow holds (5 seconds each). This takes about 3 minutes. Then spend 2 minutes doing diaphragmatic breathing while visualizing your arousal scale. This primes your body and mind for control throughout the day.',
-      },
-      {
-        title: 'Training Sessions (15-20 minutes, 3-4x/week)',
-        content: 'Schedule dedicated training sessions on alternating days. Use the full start-stop method with careful tracking. Aim for at least 3-5 complete cycles per session. End each session by noting your metrics in the app and reflecting on what worked well. Keep sessions to 20 minutes maximum to maintain focus.',
-      },
-      {
-        title: 'Evening Wind-Down (3 minutes)',
-        content: 'Before bed, do a brief kegel routine (10 quick squeezes, 5 long holds) and practice the 4-7-8 breathing technique for relaxation. This reinforces the mind-body connection and helps recovery between training sessions. It also improves sleep quality, which supports overall sexual health.',
-      },
-    ],
-    tips: [
-      'Link new habits to existing ones (kegels during morning coffee)',
-      'Use app reminders to stay consistent',
-      'Start with just the morning routine for week one',
-      'Add training sessions in week two once morning routine is habitual',
-      'Track streak of consecutive days to build momentum',
-    ],
-  },
+  }
 }
 
 export default async function GuidePage({ params }: PageProps) {
   const { slug } = await params
-  const guide = GUIDE_TOPICS.find((g) => g.slug === slug)
-  const content = GUIDE_CONTENT[slug]
+  const guide = EXPANDED_GUIDE_TOPICS.find((g) => g.slug === slug)
+  const specificContent = GUIDE_CONTENT[slug]
 
-  if (!guide || !content) {
+  if (!guide) {
     notFound()
   }
 
+  // Use specific content if available, otherwise use default
+  const content = specificContent || getDefaultContent(guide)
+
   // Find related guides (same category, excluding current)
-  const relatedGuides = GUIDE_TOPICS.filter(
-    (g) => g.category === guide.category && g.slug !== guide.slug
-  ).slice(0, 2)
+  const categoryGuides = getGuidesByCategory(guide.category)
+  const relatedGuides = categoryGuides.filter((g) => g.slug !== guide.slug).slice(0, 3)
+
+  // Find guides from other categories for cross-linking
+  const otherCategoryGuides = EXPANDED_GUIDE_TOPICS
+    .filter((g) => g.category !== guide.category && g.slug !== guide.slug && 'featured' in g && g.featured)
+    .slice(0, 2)
 
   // Article structured data
   const articleJsonLd = {
@@ -293,8 +105,9 @@ export default async function GuidePage({ params }: PageProps) {
       },
     },
     mainEntityOfPage: `${SITE_CONFIG.url}/guides/${guide.slug}`,
-    datePublished: '2024-01-01',
-    dateModified: new Date().toISOString(),
+    datePublished: guide.publishedAt,
+    dateModified: guide.updatedAt,
+    keywords: guide.keywords.join(', '),
   }
 
   return (
@@ -311,10 +124,19 @@ export default async function GuidePage({ params }: PageProps) {
       {/* Header */}
       <header className="border-b border-border">
         <div className="max-w-3xl mx-auto px-4 py-6">
-          <Link href="/" className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
-            <Timer className="w-5 h-5" />
-            <span className="font-semibold">Stamina Timer</span>
-          </Link>
+          <div className="flex items-center justify-between">
+            <Link href="/" className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
+              <Timer className="w-5 h-5" />
+              <span className="font-semibold">Stamina Timer</span>
+            </Link>
+            <nav className="hidden md:flex items-center gap-6 text-sm">
+              <Link href="/guides" className="text-muted-foreground hover:text-foreground transition-colors">Guides</Link>
+              <Link href="/faq" className="text-muted-foreground hover:text-foreground transition-colors">FAQ</Link>
+              <Link href="/login" className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors">
+                Start Training
+              </Link>
+            </nav>
+          </div>
         </div>
       </header>
 
@@ -337,7 +159,7 @@ export default async function GuidePage({ params }: PageProps) {
           </h1>
 
           {/* Meta */}
-          <div className="flex items-center gap-4 text-sm text-muted-foreground mb-8">
+          <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-8">
             <span className="flex items-center gap-1">
               <Clock className="w-4 h-4" />
               {content.readTime}
@@ -345,6 +167,9 @@ export default async function GuidePage({ params }: PageProps) {
             <span className="capitalize px-2 py-0.5 bg-primary/10 text-primary rounded">
               {guide.category}
             </span>
+            {'featured' in guide && guide.featured && (
+              <span className="text-amber-600 font-medium">★ Featured</span>
+            )}
           </div>
 
           {/* Intro */}
@@ -352,10 +177,30 @@ export default async function GuidePage({ params }: PageProps) {
             {guide.description}
           </p>
 
+          {/* Table of Contents */}
+          <div className="mb-12 p-6 rounded-xl bg-card border border-border">
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <BookOpen className="w-5 h-5" />
+              In This Guide
+            </h2>
+            <ul className="space-y-2">
+              {content.sections.map((section, i) => (
+                <li key={i}>
+                  <a
+                    href={`#section-${i}`}
+                    className="text-muted-foreground hover:text-primary transition-colors"
+                  >
+                    {i + 1}. {section.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+
           {/* Content Sections */}
           <div className="space-y-12">
             {content.sections.map((section, i) => (
-              <section key={i}>
+              <section key={i} id={`section-${i}`} className="scroll-mt-24">
                 <h2 className="text-2xl font-bold mb-4">{section.title}</h2>
                 <p className="text-foreground/90 leading-relaxed">{section.content}</p>
               </section>
@@ -390,10 +235,10 @@ export default async function GuidePage({ params }: PageProps) {
             </Link>
           </div>
 
-          {/* Related Guides */}
+          {/* Related Guides - Same Category */}
           {relatedGuides.length > 0 && (
             <div className="mt-16">
-              <h3 className="text-xl font-bold mb-6">Related Guides</h3>
+              <h3 className="text-xl font-bold mb-6">More {guide.category.charAt(0).toUpperCase() + guide.category.slice(1)} Guides</h3>
               <div className="grid gap-4">
                 {relatedGuides.map((related) => (
                   <Link
@@ -404,7 +249,7 @@ export default async function GuidePage({ params }: PageProps) {
                     <h4 className="font-semibold group-hover:text-primary transition-colors">
                       {related.title}
                     </h4>
-                    <p className="text-sm text-muted-foreground mt-1">
+                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
                       {related.description}
                     </p>
                   </Link>
@@ -412,6 +257,44 @@ export default async function GuidePage({ params }: PageProps) {
               </div>
             </div>
           )}
+
+          {/* Cross-category Links */}
+          {otherCategoryGuides.length > 0 && (
+            <div className="mt-12">
+              <h3 className="text-xl font-bold mb-6">You Might Also Like</h3>
+              <div className="grid gap-4">
+                {otherCategoryGuides.map((related) => (
+                  <Link
+                    key={related.slug}
+                    href={`/guides/${related.slug}`}
+                    className="group block p-4 rounded-lg border border-border hover:border-primary/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-xs text-primary font-medium capitalize">{related.category}</span>
+                      {'featured' in related && related.featured && <span className="text-xs text-amber-600">★</span>}
+                    </div>
+                    <h4 className="font-semibold group-hover:text-primary transition-colors">
+                      {related.title}
+                    </h4>
+                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                      {related.description}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Browse All Link */}
+          <div className="mt-12 text-center">
+            <Link
+              href="/guides"
+              className="inline-flex items-center gap-2 text-primary font-medium hover:underline"
+            >
+              Browse All {EXPANDED_GUIDE_TOPICS.length}+ Guides
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
         </div>
       </article>
 

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from 'next'
 import Link from 'next/link'
-import { GUIDE_TOPICS, GUIDE_CATEGORIES, generatePageMetadata, SITE_CONFIG } from '@/lib/seo/config'
+import { generatePageMetadata, SITE_CONFIG } from '@/lib/seo/config'
+import { EXPANDED_GUIDE_TOPICS, EXPANDED_CATEGORIES, getFeaturedGuides } from '@/lib/seo/guides-data'
 import { BreadcrumbJsonLd } from '@/components/seo/JsonLd'
-import { Timer, BookOpen, ArrowRight, Brain, Dumbbell, Heart, Calendar } from 'lucide-react'
+import { Timer, BookOpen, ArrowRight, Brain, Dumbbell, Heart, Calendar, Beaker, Users, Wrench, Zap, AlertCircle, Salad } from 'lucide-react'
 
 export const metadata: Metadata = generatePageMetadata({
   title: 'Stamina Training Guides - Expert Tips & Techniques',
@@ -17,17 +18,29 @@ const categoryIcons: Record<string, React.ReactNode> = {
   exercises: <Dumbbell className="w-5 h-5" />,
   mental: <Heart className="w-5 h-5" />,
   routines: <Calendar className="w-5 h-5" />,
+  lifestyle: <Salad className="w-5 h-5" />,
+  relationships: <Users className="w-5 h-5" />,
+  science: <Beaker className="w-5 h-5" />,
+  problems: <AlertCircle className="w-5 h-5" />,
+  tools: <Wrench className="w-5 h-5" />,
+  advanced: <Zap className="w-5 h-5" />,
 }
 
 export default function GuidesPage() {
   // Group guides by category
-  const guidesByCategory = GUIDE_TOPICS.reduce((acc, guide) => {
+  const guidesByCategory = EXPANDED_GUIDE_TOPICS.reduce((acc, guide) => {
     if (!acc[guide.category]) {
       acc[guide.category] = []
     }
     acc[guide.category].push(guide)
     return acc
-  }, {} as Record<string, typeof GUIDE_TOPICS[number][]>)
+  }, {} as Record<string, typeof EXPANDED_GUIDE_TOPICS[number][]>)
+
+  const featuredGuides = getFeaturedGuides()
+
+  // Order categories for display
+  const categoryOrder = ['fundamentals', 'techniques', 'exercises', 'mental', 'routines', 'problems', 'lifestyle', 'relationships', 'science', 'tools', 'advanced']
+  const orderedCategories = categoryOrder.filter(cat => guidesByCategory[cat])
 
   return (
     <div className="min-h-screen bg-background">
@@ -40,23 +53,34 @@ export default function GuidesPage() {
 
       {/* Header */}
       <header className="border-b border-border">
-        <div className="max-w-4xl mx-auto px-4 py-6">
-          <Link href="/" className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors mb-6">
-            <Timer className="w-5 h-5" />
-            <span className="font-semibold">Stamina Timer</span>
-          </Link>
+        <div className="max-w-6xl mx-auto px-4 py-6">
+          <div className="flex items-center justify-between">
+            <Link href="/" className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
+              <Timer className="w-5 h-5" />
+              <span className="font-semibold">Stamina Timer</span>
+            </Link>
+            <nav className="hidden md:flex items-center gap-6 text-sm">
+              <Link href="/guides" className="text-foreground font-medium">Guides</Link>
+              <Link href="/faq" className="text-muted-foreground hover:text-foreground transition-colors">FAQ</Link>
+              <Link href="/login" className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors">
+                Start Training
+              </Link>
+            </nav>
+          </div>
         </div>
       </header>
 
       {/* Hero Section */}
       <section className="py-16 md:py-24 border-b border-border">
-        <div className="max-w-4xl mx-auto px-4 text-center">
+        <div className="max-w-6xl mx-auto px-4 text-center">
           <h1 className="text-4xl md:text-5xl font-bold mb-6">
             Stamina Training Guides
           </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-8">
-            Science-backed techniques and expert advice to help you build lasting stamina and control.
-            Start your journey to better performance today.
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-4">
+            {EXPANDED_GUIDE_TOPICS.length}+ comprehensive guides on building lasting stamina and control.
+          </p>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto mb-8">
+            Science-backed techniques and expert advice for real results.
           </p>
           <Link
             href="/login"
@@ -68,52 +92,139 @@ export default function GuidesPage() {
         </div>
       </section>
 
-      {/* Guides by Category */}
-      <main className="py-16">
-        <div className="max-w-4xl mx-auto px-4">
-          {Object.entries(guidesByCategory).map(([category, guides]) => (
-            <section key={category} className="mb-16">
-              <div className="flex items-center gap-3 mb-6">
-                <div className="w-10 h-10 rounded-lg bg-primary/10 text-primary flex items-center justify-center">
-                  {categoryIcons[category]}
-                </div>
-                <div>
-                  <h2 className="text-2xl font-bold">
-                    {GUIDE_CATEGORIES[category as keyof typeof GUIDE_CATEGORIES]?.title || category}
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    {GUIDE_CATEGORIES[category as keyof typeof GUIDE_CATEGORIES]?.description}
-                  </p>
-                </div>
-              </div>
-
-              <div className="grid gap-4">
-                {guides.map((guide) => (
-                  <Link
-                    key={guide.slug}
-                    href={`/guides/${guide.slug}`}
-                    className="group block p-6 rounded-xl border border-border bg-card hover:border-primary/50 hover:shadow-lg transition-all"
-                  >
-                    <h3 className="text-lg font-semibold mb-2 group-hover:text-primary transition-colors">
-                      {guide.title}
-                    </h3>
-                    <p className="text-muted-foreground text-sm mb-4">
-                      {guide.description}
-                    </p>
-                    <span className="inline-flex items-center gap-1 text-sm text-primary font-medium">
-                      Read Guide
-                      <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+      {/* Featured Guides */}
+      {featuredGuides.length > 0 && (
+        <section className="py-12 border-b border-border bg-card/50">
+          <div className="max-w-6xl mx-auto px-4">
+            <h2 className="text-2xl font-bold mb-6">Featured Guides</h2>
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {featuredGuides.slice(0, 6).map((guide) => (
+                <Link
+                  key={guide.slug}
+                  href={`/guides/${guide.slug}`}
+                  className="group block p-6 rounded-xl border border-primary/20 bg-primary/5 hover:border-primary/50 hover:shadow-lg transition-all"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-xs font-medium text-primary px-2 py-0.5 bg-primary/10 rounded capitalize">
+                      {guide.category}
                     </span>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          ))}
+                    <span className="text-xs text-amber-600 font-medium">★ Featured</span>
+                  </div>
+                  <h3 className="text-lg font-semibold mb-2 group-hover:text-primary transition-colors">
+                    {guide.title}
+                  </h3>
+                  <p className="text-muted-foreground text-sm line-clamp-2">
+                    {guide.description}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Category Navigation */}
+      <section className="py-6 border-b border-border sticky top-0 bg-background/95 backdrop-blur z-10">
+        <div className="max-w-6xl mx-auto px-4">
+          <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+            {orderedCategories.map((category) => {
+              const cat = EXPANDED_CATEGORIES[category as keyof typeof EXPANDED_CATEGORIES]
+              return (
+                <a
+                  key={category}
+                  href={`#${category}`}
+                  className="flex items-center gap-2 px-4 py-2 rounded-full border border-border bg-card hover:border-primary/50 text-sm font-medium whitespace-nowrap transition-colors"
+                >
+                  {categoryIcons[category]}
+                  {cat?.title || category}
+                  <span className="text-xs text-muted-foreground">({guidesByCategory[category].length})</span>
+                </a>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Guides by Category */}
+      <main className="py-12">
+        <div className="max-w-6xl mx-auto px-4">
+          {orderedCategories.map((category) => {
+            const guides = guidesByCategory[category]
+            const cat = EXPANDED_CATEGORIES[category as keyof typeof EXPANDED_CATEGORIES]
+
+            return (
+              <section key={category} id={category} className="mb-16 scroll-mt-24">
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="w-10 h-10 rounded-lg bg-primary/10 text-primary flex items-center justify-center">
+                    {categoryIcons[category]}
+                  </div>
+                  <div>
+                    <h2 className="text-2xl font-bold">
+                      {cat?.title || category}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      {cat?.description} • {guides.length} guides
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid md:grid-cols-2 gap-4">
+                  {guides.map((guide) => (
+                    <Link
+                      key={guide.slug}
+                      href={`/guides/${guide.slug}`}
+                      className="group block p-5 rounded-xl border border-border bg-card hover:border-primary/50 hover:shadow-lg transition-all"
+                    >
+                      <div className="flex items-center justify-between mb-2">
+                        <h3 className="text-base font-semibold group-hover:text-primary transition-colors line-clamp-1">
+                          {guide.title}
+                        </h3>
+                        {'featured' in guide && guide.featured && (
+                          <span className="text-xs text-amber-600 font-medium">★</span>
+                        )}
+                      </div>
+                      <p className="text-muted-foreground text-sm mb-3 line-clamp-2">
+                        {guide.description}
+                      </p>
+                      <span className="inline-flex items-center gap-1 text-sm text-primary font-medium">
+                        Read Guide
+                        <ArrowRight className="w-3 h-3 group-hover:translate-x-1 transition-transform" />
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )
+          })}
         </div>
       </main>
 
+      {/* Stats Section */}
+      <section className="py-12 border-t border-border bg-card/50">
+        <div className="max-w-6xl mx-auto px-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+            <div>
+              <div className="text-3xl font-bold text-primary">{EXPANDED_GUIDE_TOPICS.length}+</div>
+              <div className="text-sm text-muted-foreground">Training Guides</div>
+            </div>
+            <div>
+              <div className="text-3xl font-bold text-primary">{Object.keys(EXPANDED_CATEGORIES).length}</div>
+              <div className="text-sm text-muted-foreground">Categories</div>
+            </div>
+            <div>
+              <div className="text-3xl font-bold text-primary">100%</div>
+              <div className="text-sm text-muted-foreground">Free Access</div>
+            </div>
+            <div>
+              <div className="text-3xl font-bold text-primary">Science</div>
+              <div className="text-sm text-muted-foreground">Backed Methods</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* CTA Section */}
-      <section className="py-16 bg-card border-t border-border">
+      <section className="py-16 border-t border-border">
         <div className="max-w-4xl mx-auto px-4 text-center">
           <h2 className="text-2xl md:text-3xl font-bold mb-4">
             Ready to Put This Into Practice?
@@ -134,7 +245,7 @@ export default function GuidesPage() {
 
       {/* Footer with internal links */}
       <footer className="border-t border-border py-12">
-        <div className="max-w-4xl mx-auto px-4">
+        <div className="max-w-6xl mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-between items-center gap-6">
             <Link href="/" className="flex items-center gap-2">
               <Timer className="w-5 h-5 text-primary" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -333,7 +333,8 @@ export default function Home() {
             <div className="hidden md:flex items-center gap-8">
               <a href="#features" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Features</a>
               <a href="#how-it-works" className="text-sm text-muted-foreground hover:text-foreground transition-colors">How It Works</a>
-              <a href="#testimonials" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Reviews</a>
+              <Link href="/guides" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Guides</Link>
+              <Link href="/faq" className="text-sm text-muted-foreground hover:text-foreground transition-colors">FAQ</Link>
             </div>
 
             <div className="flex items-center gap-3">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next'
-import { GUIDE_TOPICS } from '@/lib/seo/config'
+import { EXPANDED_GUIDE_TOPICS } from '@/lib/seo/guides-data'
 
 const baseUrl = 'https://staminatimer.com'
 
@@ -52,12 +52,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ]
 
-  // Dynamic guide pages - programmatic SEO
-  const guidePages: MetadataRoute.Sitemap = GUIDE_TOPICS.map((guide) => ({
+  // Dynamic guide pages - programmatic SEO (60+ pages)
+  const guidePages: MetadataRoute.Sitemap = EXPANDED_GUIDE_TOPICS.map((guide) => ({
     url: `${baseUrl}/guides/${guide.slug}`,
-    lastModified: currentDate,
+    lastModified: guide.updatedAt,
     changeFrequency: 'monthly' as const,
-    priority: 0.8,
+    priority: guide.priority,
   }))
 
   return [...staticPages, ...guidePages]

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -10,7 +10,8 @@ import {
   Bot,
   Settings,
   Menu,
-  X
+  X,
+  BookOpen
 } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -21,7 +22,8 @@ const navigationItems = [
   { title: 'Home', href: '/dashboard', icon: Home },
   { title: 'Train', href: '/training', icon: Timer },
   { title: 'Progress', href: '/progress', icon: TrendingUp },
-  { title: 'AI Coach', href: '/ai-coach', icon: Bot }
+  { title: 'AI Coach', href: '/ai-coach', icon: Bot },
+  { title: 'Guides', href: '/guides', icon: BookOpen }
 ]
 
 type AppNavigationProps = {

--- a/src/lib/seo/guides-data.ts
+++ b/src/lib/seo/guides-data.ts
@@ -1,0 +1,1173 @@
+/**
+ * Comprehensive Guide Content Data for pSEO
+ *
+ * This file contains all guide topics and their full content for scalable pSEO.
+ * Each guide is designed to target specific keywords with unique, valuable content.
+ */
+
+import type { GuideContent } from './types'
+
+// =============================================================================
+// GUIDE TOPICS - Expanded for massive pSEO coverage
+// =============================================================================
+
+export const EXPANDED_GUIDE_TOPICS = [
+  // ===== FUNDAMENTALS =====
+  {
+    slug: 'stamina-training-basics',
+    title: 'Stamina Training Basics: Complete Beginner Guide',
+    description: 'Learn the fundamentals of stamina training with science-backed techniques for lasting improvement. Start your journey to better control today.',
+    keywords: ['stamina training', 'stamina basics', 'how to last longer', 'stamina exercises', 'beginner stamina guide'],
+    category: 'fundamentals',
+    priority: 0.9,
+    publishedAt: '2024-01-15T00:00:00Z',
+    updatedAt: '2024-12-01T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'what-is-stamina-training',
+    title: 'What is Stamina Training? Science & Benefits Explained',
+    description: 'Discover what stamina training is, how it works scientifically, and the proven benefits for men seeking better control and confidence.',
+    keywords: ['what is stamina training', 'stamina training definition', 'stamina benefits', 'stamina science'],
+    category: 'fundamentals',
+    priority: 0.8,
+    publishedAt: '2024-01-18T00:00:00Z',
+    updatedAt: '2024-11-28T00:00:00Z',
+  },
+  {
+    slug: 'how-long-to-see-results',
+    title: 'How Long Does It Take to See Stamina Training Results?',
+    description: 'Realistic timelines and expectations for stamina training results. Learn what affects your progress and how to optimize your training.',
+    keywords: ['stamina training results', 'how long stamina improvement', 'stamina progress timeline', 'when will I see results'],
+    category: 'fundamentals',
+    priority: 0.8,
+    publishedAt: '2024-01-22T00:00:00Z',
+    updatedAt: '2024-11-25T00:00:00Z',
+  },
+  {
+    slug: 'tracking-progress-stamina',
+    title: 'How to Track Your Stamina Progress Effectively',
+    description: 'Learn how to effectively track and measure your stamina improvement over time with data-driven methods and key metrics.',
+    keywords: ['track stamina progress', 'stamina improvement', 'progress tracking', 'stamina metrics', 'measure stamina'],
+    category: 'fundamentals',
+    priority: 0.7,
+    publishedAt: '2024-04-01T00:00:00Z',
+    updatedAt: '2024-10-20T00:00:00Z',
+  },
+  {
+    slug: 'stamina-training-myths',
+    title: '10 Stamina Training Myths Debunked by Science',
+    description: 'Separate fact from fiction with our evidence-based breakdown of the most common stamina training myths and misconceptions.',
+    keywords: ['stamina myths', 'stamina training facts', 'stamina misconceptions', 'stamina truth'],
+    category: 'fundamentals',
+    priority: 0.7,
+    publishedAt: '2024-02-05T00:00:00Z',
+    updatedAt: '2024-11-12T00:00:00Z',
+  },
+
+  // ===== TECHNIQUES =====
+  {
+    slug: 'edging-techniques',
+    title: 'Edging Techniques for Beginners: Step-by-Step Guide',
+    description: 'Master the art of edging with step-by-step techniques that help build control and extend duration safely and effectively.',
+    keywords: ['edging techniques', 'edging for beginners', 'edge control', 'stamina edging', 'how to edge'],
+    category: 'techniques',
+    priority: 0.9,
+    publishedAt: '2024-01-20T00:00:00Z',
+    updatedAt: '2024-11-15T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'advanced-edging-techniques',
+    title: 'Advanced Edging Techniques for Experienced Practitioners',
+    description: 'Take your edging practice to the next level with advanced techniques, variations, and strategies for maximum control.',
+    keywords: ['advanced edging', 'edging mastery', 'expert edging techniques', 'edging variations'],
+    category: 'techniques',
+    priority: 0.7,
+    publishedAt: '2024-03-10T00:00:00Z',
+    updatedAt: '2024-11-08T00:00:00Z',
+  },
+  {
+    slug: 'start-stop-method',
+    title: 'The Start-Stop Method: Complete Training Guide',
+    description: 'A comprehensive guide to the start-stop technique - one of the most effective and scientifically-proven methods for building stamina.',
+    keywords: ['start stop method', 'start stop technique', 'stamina method', 'lasting longer technique'],
+    category: 'techniques',
+    priority: 0.9,
+    publishedAt: '2024-03-15T00:00:00Z',
+    updatedAt: '2024-11-10T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'squeeze-technique',
+    title: 'The Squeeze Technique Explained: How to Use It',
+    description: 'Learn the squeeze technique developed by Masters and Johnson - a clinically proven method for improving control and lasting longer.',
+    keywords: ['squeeze technique', 'squeeze method', 'masters and johnson technique', 'stamina squeeze'],
+    category: 'techniques',
+    priority: 0.8,
+    publishedAt: '2024-02-20T00:00:00Z',
+    updatedAt: '2024-11-18T00:00:00Z',
+  },
+  {
+    slug: 'breathing-techniques-stamina',
+    title: 'Breathing Techniques for Better Stamina and Control',
+    description: 'Control your arousal and extend your sessions with proven breathing techniques and mindfulness practices.',
+    keywords: ['breathing techniques', 'stamina breathing', 'arousal control', 'mindfulness stamina', 'breath control'],
+    category: 'techniques',
+    priority: 0.8,
+    publishedAt: '2024-02-15T00:00:00Z',
+    updatedAt: '2024-10-30T00:00:00Z',
+  },
+  {
+    slug: 'sensate-focus-exercises',
+    title: 'Sensate Focus Exercises for Stamina Improvement',
+    description: 'Discover sensate focus exercises - a therapeutic technique that helps reduce anxiety and improve awareness during intimacy.',
+    keywords: ['sensate focus', 'sensate exercises', 'mindful intimacy', 'arousal awareness'],
+    category: 'techniques',
+    priority: 0.7,
+    publishedAt: '2024-04-05T00:00:00Z',
+    updatedAt: '2024-10-25T00:00:00Z',
+  },
+  {
+    slug: 'distraction-techniques',
+    title: 'Distraction Techniques: Do They Work for Stamina?',
+    description: 'Explore the pros and cons of distraction techniques for stamina, and learn better alternatives for lasting improvement.',
+    keywords: ['distraction techniques', 'think of something else', 'mental distraction stamina', 'stamina mental tricks'],
+    category: 'techniques',
+    priority: 0.6,
+    publishedAt: '2024-04-20T00:00:00Z',
+    updatedAt: '2024-10-15T00:00:00Z',
+  },
+  {
+    slug: 'reverse-kegels',
+    title: 'Reverse Kegels: The Missing Piece in Stamina Training',
+    description: 'Learn about reverse kegels - the often overlooked exercise that complements regular kegels for complete pelvic floor control.',
+    keywords: ['reverse kegels', 'reverse kegel exercises', 'pelvic floor relaxation', 'kegel alternatives'],
+    category: 'techniques',
+    priority: 0.7,
+    publishedAt: '2024-05-01T00:00:00Z',
+    updatedAt: '2024-11-02T00:00:00Z',
+  },
+  {
+    slug: 'arousal-control-techniques',
+    title: 'Arousal Control Techniques: Master Your Response',
+    description: 'Comprehensive guide to recognizing and controlling your arousal levels for better stamina and more satisfying experiences.',
+    keywords: ['arousal control', 'control arousal levels', 'arousal awareness', 'arousal management'],
+    category: 'techniques',
+    priority: 0.8,
+    publishedAt: '2024-03-25T00:00:00Z',
+    updatedAt: '2024-11-05T00:00:00Z',
+  },
+  {
+    slug: 'point-of-no-return',
+    title: 'Understanding the Point of No Return (PONR)',
+    description: 'Learn to recognize and control the point of no return - the critical skill that separates beginners from stamina masters.',
+    keywords: ['point of no return', 'PONR', 'ejaculatory inevitability', 'arousal threshold'],
+    category: 'techniques',
+    priority: 0.8,
+    publishedAt: '2024-02-28T00:00:00Z',
+    updatedAt: '2024-11-20T00:00:00Z',
+  },
+
+  // ===== EXERCISES =====
+  {
+    slug: 'kegel-exercises-men',
+    title: 'Kegel Exercises for Men: Complete Training Guide',
+    description: 'Strengthen your pelvic floor muscles with targeted kegel exercises designed specifically for men seeking better control.',
+    keywords: ['kegel exercises men', 'male kegel', 'pelvic floor exercises', 'PC muscle training', 'kegels for men'],
+    category: 'exercises',
+    priority: 0.9,
+    publishedAt: '2024-02-01T00:00:00Z',
+    updatedAt: '2024-11-20T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'how-to-do-kegels-correctly',
+    title: 'How to Do Kegels Correctly: Avoid Common Mistakes',
+    description: 'Step-by-step instructions for performing kegel exercises correctly, plus the most common mistakes and how to avoid them.',
+    keywords: ['how to do kegels', 'kegel instructions', 'kegel mistakes', 'correct kegel form'],
+    category: 'exercises',
+    priority: 0.8,
+    publishedAt: '2024-02-10T00:00:00Z',
+    updatedAt: '2024-11-15T00:00:00Z',
+  },
+  {
+    slug: 'pelvic-floor-strength-test',
+    title: 'Pelvic Floor Strength Test: Assess Your Starting Point',
+    description: 'Simple tests to assess your current pelvic floor strength and track your improvement over time with kegel exercises.',
+    keywords: ['pelvic floor test', 'kegel strength test', 'PC muscle assessment', 'pelvic floor strength'],
+    category: 'exercises',
+    priority: 0.6,
+    publishedAt: '2024-05-10T00:00:00Z',
+    updatedAt: '2024-10-28T00:00:00Z',
+  },
+  {
+    slug: 'stamina-exercises-without-equipment',
+    title: '15 Stamina Exercises You Can Do Without Equipment',
+    description: 'Build stamina anywhere with these effective exercises that require no equipment - perfect for home training.',
+    keywords: ['stamina exercises', 'no equipment exercises', 'home stamina training', 'bodyweight stamina'],
+    category: 'exercises',
+    priority: 0.7,
+    publishedAt: '2024-04-12T00:00:00Z',
+    updatedAt: '2024-11-01T00:00:00Z',
+  },
+  {
+    slug: 'cardio-for-stamina',
+    title: 'How Cardio Exercise Improves Sexual Stamina',
+    description: 'Discover the connection between cardiovascular fitness and sexual stamina, plus the best cardio exercises for improvement.',
+    keywords: ['cardio stamina', 'exercise sexual stamina', 'fitness stamina', 'cardiovascular endurance'],
+    category: 'exercises',
+    priority: 0.6,
+    publishedAt: '2024-05-15T00:00:00Z',
+    updatedAt: '2024-10-22T00:00:00Z',
+  },
+  {
+    slug: 'yoga-for-stamina',
+    title: 'Yoga for Sexual Stamina: Best Poses and Practices',
+    description: 'Explore yoga poses and breathing practices that enhance sexual stamina, flexibility, and mind-body connection.',
+    keywords: ['yoga stamina', 'yoga sexual health', 'yoga poses stamina', 'tantric yoga'],
+    category: 'exercises',
+    priority: 0.6,
+    publishedAt: '2024-05-20T00:00:00Z',
+    updatedAt: '2024-10-18T00:00:00Z',
+  },
+  {
+    slug: 'core-exercises-stamina',
+    title: 'Core Exercises That Improve Sexual Stamina',
+    description: 'Strengthen your core for better stamina and performance with these targeted exercises and workout routines.',
+    keywords: ['core exercises stamina', 'abs stamina', 'core strength sexual', 'core workout stamina'],
+    category: 'exercises',
+    priority: 0.6,
+    publishedAt: '2024-06-01T00:00:00Z',
+    updatedAt: '2024-10-12T00:00:00Z',
+  },
+
+  // ===== MENTAL TRAINING =====
+  {
+    slug: 'performance-anxiety-tips',
+    title: 'Overcoming Performance Anxiety: Complete Guide',
+    description: 'Practical strategies to overcome performance anxiety and build lasting confidence in intimate situations.',
+    keywords: ['performance anxiety', 'sexual confidence', 'anxiety tips', 'bedroom confidence', 'sexual anxiety'],
+    category: 'mental',
+    priority: 0.9,
+    publishedAt: '2024-03-01T00:00:00Z',
+    updatedAt: '2024-11-01T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'mindfulness-for-stamina',
+    title: 'Mindfulness for Better Stamina: A Practical Guide',
+    description: 'Learn how mindfulness practices can dramatically improve your stamina by enhancing body awareness and reducing anxiety.',
+    keywords: ['mindfulness stamina', 'mindful intimacy', 'present moment awareness', 'meditation stamina'],
+    category: 'mental',
+    priority: 0.7,
+    publishedAt: '2024-03-20T00:00:00Z',
+    updatedAt: '2024-10-28T00:00:00Z',
+  },
+  {
+    slug: 'confidence-building-exercises',
+    title: 'Confidence Building Exercises for Better Performance',
+    description: 'Build unshakeable confidence with these mental exercises and techniques proven to improve intimate performance.',
+    keywords: ['confidence building', 'sexual confidence exercises', 'self-confidence intimacy', 'mental confidence'],
+    category: 'mental',
+    priority: 0.7,
+    publishedAt: '2024-04-08T00:00:00Z',
+    updatedAt: '2024-10-25T00:00:00Z',
+  },
+  {
+    slug: 'visualization-techniques',
+    title: 'Visualization Techniques for Stamina Training',
+    description: 'Use the power of visualization to enhance your stamina training and build mental pathways for better control.',
+    keywords: ['visualization stamina', 'mental rehearsal', 'stamina visualization', 'mental training'],
+    category: 'mental',
+    priority: 0.6,
+    publishedAt: '2024-04-25T00:00:00Z',
+    updatedAt: '2024-10-20T00:00:00Z',
+  },
+  {
+    slug: 'stress-and-stamina',
+    title: 'How Stress Affects Your Stamina (And What to Do)',
+    description: 'Understand the connection between stress and stamina, plus actionable strategies to manage stress for better performance.',
+    keywords: ['stress stamina', 'stress sexual performance', 'cortisol stamina', 'stress management'],
+    category: 'mental',
+    priority: 0.7,
+    publishedAt: '2024-05-05T00:00:00Z',
+    updatedAt: '2024-11-08T00:00:00Z',
+  },
+  {
+    slug: 'cognitive-behavioral-techniques',
+    title: 'CBT Techniques for Lasting Longer',
+    description: 'Apply cognitive behavioral therapy techniques to overcome mental blocks and improve your stamina naturally.',
+    keywords: ['CBT stamina', 'cognitive behavioral techniques', 'mental blocks stamina', 'thought patterns'],
+    category: 'mental',
+    priority: 0.6,
+    publishedAt: '2024-06-10T00:00:00Z',
+    updatedAt: '2024-10-15T00:00:00Z',
+  },
+  {
+    slug: 'dealing-with-setbacks',
+    title: 'Dealing with Setbacks in Stamina Training',
+    description: 'Learn how to handle setbacks, plateaus, and frustrations in your stamina training journey with resilience.',
+    keywords: ['stamina setbacks', 'training plateau', 'stamina frustration', 'overcoming setbacks'],
+    category: 'mental',
+    priority: 0.6,
+    publishedAt: '2024-06-15T00:00:00Z',
+    updatedAt: '2024-10-10T00:00:00Z',
+  },
+
+  // ===== ROUTINES =====
+  {
+    slug: 'daily-stamina-routine',
+    title: 'Building a Daily Stamina Routine That Works',
+    description: 'Create an effective daily routine that fits your lifestyle and delivers consistent stamina improvements.',
+    keywords: ['daily stamina routine', 'stamina workout', 'daily exercises', 'stamina schedule'],
+    category: 'routines',
+    priority: 0.8,
+    publishedAt: '2024-04-15T00:00:00Z',
+    updatedAt: '2024-11-05T00:00:00Z',
+  },
+  {
+    slug: 'beginner-stamina-program',
+    title: '30-Day Beginner Stamina Training Program',
+    description: 'A complete 30-day program designed for beginners to build a strong foundation in stamina training.',
+    keywords: ['beginner stamina program', '30 day stamina', 'stamina training plan', 'starter program'],
+    category: 'routines',
+    priority: 0.8,
+    publishedAt: '2024-03-05T00:00:00Z',
+    updatedAt: '2024-11-12T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'intermediate-stamina-program',
+    title: '60-Day Intermediate Stamina Training Program',
+    description: 'Take your training to the next level with this 60-day intermediate program for continued improvement.',
+    keywords: ['intermediate stamina', '60 day program', 'advanced beginner stamina', 'level up stamina'],
+    category: 'routines',
+    priority: 0.7,
+    publishedAt: '2024-04-02T00:00:00Z',
+    updatedAt: '2024-10-30T00:00:00Z',
+  },
+  {
+    slug: 'advanced-stamina-program',
+    title: '90-Day Advanced Stamina Mastery Program',
+    description: 'The ultimate 90-day program for experienced practitioners seeking complete mastery over their stamina.',
+    keywords: ['advanced stamina program', '90 day training', 'stamina mastery', 'expert level'],
+    category: 'routines',
+    priority: 0.7,
+    publishedAt: '2024-04-18T00:00:00Z',
+    updatedAt: '2024-10-25T00:00:00Z',
+  },
+  {
+    slug: '5-minute-stamina-routine',
+    title: '5-Minute Daily Stamina Routine for Busy Men',
+    description: 'A quick but effective 5-minute daily routine for men who want results but have limited time.',
+    keywords: ['5 minute stamina', 'quick stamina routine', 'busy schedule stamina', 'fast stamina workout'],
+    category: 'routines',
+    priority: 0.7,
+    publishedAt: '2024-05-08T00:00:00Z',
+    updatedAt: '2024-11-02T00:00:00Z',
+  },
+  {
+    slug: 'weekly-training-schedule',
+    title: 'Optimal Weekly Stamina Training Schedule',
+    description: 'Learn how to structure your week for maximum stamina gains with rest days and training variety.',
+    keywords: ['weekly stamina schedule', 'training frequency', 'stamina workout plan', 'weekly routine'],
+    category: 'routines',
+    priority: 0.7,
+    publishedAt: '2024-05-12T00:00:00Z',
+    updatedAt: '2024-10-28T00:00:00Z',
+  },
+  {
+    slug: 'morning-stamina-routine',
+    title: 'Morning Stamina Routine: Start Your Day Right',
+    description: 'A morning-focused routine that sets you up for success and builds consistent training habits.',
+    keywords: ['morning stamina routine', 'morning exercises', 'start day stamina', 'morning workout'],
+    category: 'routines',
+    priority: 0.6,
+    publishedAt: '2024-06-05T00:00:00Z',
+    updatedAt: '2024-10-20T00:00:00Z',
+  },
+  {
+    slug: 'evening-stamina-routine',
+    title: 'Evening Stamina Routine for Better Results',
+    description: 'An evening-focused routine perfect for winding down while building stamina and control.',
+    keywords: ['evening stamina routine', 'night exercises', 'bedtime routine stamina', 'evening workout'],
+    category: 'routines',
+    priority: 0.6,
+    publishedAt: '2024-06-08T00:00:00Z',
+    updatedAt: '2024-10-18T00:00:00Z',
+  },
+
+  // ===== LIFESTYLE =====
+  {
+    slug: 'diet-for-stamina',
+    title: 'Best Foods and Diet for Better Stamina',
+    description: 'Discover which foods boost stamina and sexual health, plus a sample meal plan for optimal performance.',
+    keywords: ['diet stamina', 'foods for stamina', 'nutrition sexual health', 'stamina diet plan'],
+    category: 'lifestyle',
+    priority: 0.7,
+    publishedAt: '2024-05-18T00:00:00Z',
+    updatedAt: '2024-11-05T00:00:00Z',
+  },
+  {
+    slug: 'sleep-and-stamina',
+    title: 'How Sleep Affects Your Stamina and Performance',
+    description: 'Understand the critical connection between sleep quality and sexual stamina, plus tips for better rest.',
+    keywords: ['sleep stamina', 'rest sexual health', 'sleep performance', 'recovery stamina'],
+    category: 'lifestyle',
+    priority: 0.6,
+    publishedAt: '2024-05-22T00:00:00Z',
+    updatedAt: '2024-10-30T00:00:00Z',
+  },
+  {
+    slug: 'alcohol-and-stamina',
+    title: 'Alcohol and Stamina: What You Need to Know',
+    description: 'How alcohol affects your stamina and sexual performance, plus guidelines for moderate consumption.',
+    keywords: ['alcohol stamina', 'drinking sexual performance', 'alcohol effects', 'moderation stamina'],
+    category: 'lifestyle',
+    priority: 0.6,
+    publishedAt: '2024-06-12T00:00:00Z',
+    updatedAt: '2024-10-22T00:00:00Z',
+  },
+  {
+    slug: 'supplements-for-stamina',
+    title: 'Supplements for Stamina: What Works and What Doesn\'t',
+    description: 'Evidence-based review of supplements claimed to improve stamina - separating science from marketing.',
+    keywords: ['stamina supplements', 'natural supplements', 'vitamins stamina', 'herbal stamina'],
+    category: 'lifestyle',
+    priority: 0.7,
+    publishedAt: '2024-05-25T00:00:00Z',
+    updatedAt: '2024-11-08T00:00:00Z',
+  },
+  {
+    slug: 'exercise-and-stamina',
+    title: 'General Exercise and Its Impact on Sexual Stamina',
+    description: 'How regular physical exercise affects your sexual stamina and which types of exercise help most.',
+    keywords: ['exercise stamina', 'fitness sexual health', 'workout stamina', 'physical fitness'],
+    category: 'lifestyle',
+    priority: 0.7,
+    publishedAt: '2024-05-28T00:00:00Z',
+    updatedAt: '2024-11-01T00:00:00Z',
+  },
+  {
+    slug: 'testosterone-and-stamina',
+    title: 'Testosterone and Stamina: Understanding the Connection',
+    description: 'Learn how testosterone levels affect stamina and natural ways to optimize your hormonal health.',
+    keywords: ['testosterone stamina', 'hormones sexual health', 'natural testosterone', 'hormone optimization'],
+    category: 'lifestyle',
+    priority: 0.7,
+    publishedAt: '2024-06-18T00:00:00Z',
+    updatedAt: '2024-10-25T00:00:00Z',
+  },
+  {
+    slug: 'hydration-and-performance',
+    title: 'Hydration and Sexual Performance: The Overlooked Factor',
+    description: 'Discover how proper hydration affects your stamina and sexual performance, plus hydration guidelines.',
+    keywords: ['hydration stamina', 'water sexual health', 'dehydration performance', 'drinking water stamina'],
+    category: 'lifestyle',
+    priority: 0.5,
+    publishedAt: '2024-06-22T00:00:00Z',
+    updatedAt: '2024-10-15T00:00:00Z',
+  },
+
+  // ===== RELATIONSHIPS =====
+  {
+    slug: 'communicating-with-partner',
+    title: 'How to Talk to Your Partner About Stamina Training',
+    description: 'Practical communication strategies for discussing stamina training with your partner openly and effectively.',
+    keywords: ['partner communication', 'talking about stamina', 'relationship communication', 'partner support'],
+    category: 'relationships',
+    priority: 0.7,
+    publishedAt: '2024-06-25T00:00:00Z',
+    updatedAt: '2024-11-10T00:00:00Z',
+  },
+  {
+    slug: 'partner-exercises',
+    title: 'Stamina Training Exercises to Do with Your Partner',
+    description: 'Exercises and techniques you can practice together with your partner for mutual benefit and connection.',
+    keywords: ['partner exercises', 'couples stamina', 'together training', 'partner involvement'],
+    category: 'relationships',
+    priority: 0.7,
+    publishedAt: '2024-06-28T00:00:00Z',
+    updatedAt: '2024-11-05T00:00:00Z',
+  },
+  {
+    slug: 'intimacy-without-pressure',
+    title: 'Building Intimacy Without Performance Pressure',
+    description: 'Learn to create intimate experiences focused on connection rather than performance for better relationships.',
+    keywords: ['intimacy pressure', 'performance pressure', 'relaxed intimacy', 'connection over performance'],
+    category: 'relationships',
+    priority: 0.6,
+    publishedAt: '2024-07-02T00:00:00Z',
+    updatedAt: '2024-10-28T00:00:00Z',
+  },
+  {
+    slug: 'foreplay-and-stamina',
+    title: 'Extended Foreplay: A Stamina Strategy',
+    description: 'How extended foreplay can naturally improve your stamina and enhance satisfaction for both partners.',
+    keywords: ['foreplay stamina', 'extended foreplay', 'foreplay techniques', 'pleasure focus'],
+    category: 'relationships',
+    priority: 0.6,
+    publishedAt: '2024-07-05T00:00:00Z',
+    updatedAt: '2024-10-22T00:00:00Z',
+  },
+
+  // ===== SCIENCE & EDUCATION =====
+  {
+    slug: 'science-of-stamina',
+    title: 'The Science of Stamina: How Your Body Works',
+    description: 'Understand the physiology and neuroscience behind stamina and arousal for more effective training.',
+    keywords: ['science stamina', 'physiology arousal', 'neuroscience stamina', 'body mechanics'],
+    category: 'science',
+    priority: 0.7,
+    publishedAt: '2024-07-08T00:00:00Z',
+    updatedAt: '2024-11-12T00:00:00Z',
+  },
+  {
+    slug: 'ejaculation-control-explained',
+    title: 'Ejaculation Control: The Complete Scientific Guide',
+    description: 'Deep dive into the science of ejaculatory control - understanding the mechanisms helps you train smarter.',
+    keywords: ['ejaculation control', 'ejaculatory reflex', 'control mechanisms', 'scientific understanding'],
+    category: 'science',
+    priority: 0.8,
+    publishedAt: '2024-07-12T00:00:00Z',
+    updatedAt: '2024-11-08T00:00:00Z',
+  },
+  {
+    slug: 'neuroplasticity-and-training',
+    title: 'Neuroplasticity: How Your Brain Adapts to Stamina Training',
+    description: 'Learn how neuroplasticity allows your brain to rewire for better control through consistent practice.',
+    keywords: ['neuroplasticity stamina', 'brain training', 'neural adaptation', 'brain rewiring'],
+    category: 'science',
+    priority: 0.6,
+    publishedAt: '2024-07-15T00:00:00Z',
+    updatedAt: '2024-10-25T00:00:00Z',
+  },
+  {
+    slug: 'research-studies-stamina',
+    title: 'Research Studies on Stamina Training: What Science Says',
+    description: 'A review of clinical studies and research on stamina training techniques and their effectiveness.',
+    keywords: ['stamina research', 'clinical studies', 'scientific evidence', 'research review'],
+    category: 'science',
+    priority: 0.6,
+    publishedAt: '2024-07-18T00:00:00Z',
+    updatedAt: '2024-10-20T00:00:00Z',
+  },
+
+  // ===== PROBLEM-SPECIFIC =====
+  {
+    slug: 'premature-ejaculation-guide',
+    title: 'Premature Ejaculation: Causes, Solutions, and Training',
+    description: 'Comprehensive guide to understanding and overcoming premature ejaculation with proven techniques.',
+    keywords: ['premature ejaculation', 'PE causes', 'PE solutions', 'lasting longer PE'],
+    category: 'problems',
+    priority: 0.9,
+    publishedAt: '2024-07-22T00:00:00Z',
+    updatedAt: '2024-11-15T00:00:00Z',
+    featured: true,
+  },
+  {
+    slug: 'lifelong-vs-acquired-pe',
+    title: 'Lifelong vs Acquired PE: Different Approaches',
+    description: 'Understanding the differences between lifelong and acquired premature ejaculation for targeted treatment.',
+    keywords: ['lifelong PE', 'acquired PE', 'PE types', 'primary secondary PE'],
+    category: 'problems',
+    priority: 0.6,
+    publishedAt: '2024-07-25T00:00:00Z',
+    updatedAt: '2024-10-18T00:00:00Z',
+  },
+  {
+    slug: 'sensitivity-issues',
+    title: 'Dealing with High Sensitivity: Training Strategies',
+    description: 'Specific strategies for men dealing with high sensitivity that affects their stamina and control.',
+    keywords: ['high sensitivity', 'oversensitivity', 'sensitivity training', 'desensitization'],
+    category: 'problems',
+    priority: 0.7,
+    publishedAt: '2024-07-28T00:00:00Z',
+    updatedAt: '2024-11-02T00:00:00Z',
+  },
+  {
+    slug: 'anxiety-induced-pe',
+    title: 'Anxiety-Induced PE: Breaking the Cycle',
+    description: 'How anxiety causes premature ejaculation and proven strategies to break the anxiety-PE cycle.',
+    keywords: ['anxiety PE', 'anxiety premature', 'nervous PE', 'anxiety cycle'],
+    category: 'problems',
+    priority: 0.7,
+    publishedAt: '2024-08-01T00:00:00Z',
+    updatedAt: '2024-10-28T00:00:00Z',
+  },
+  {
+    slug: 'age-and-stamina',
+    title: 'Stamina Training at Different Ages: What Changes',
+    description: 'How age affects stamina and what adjustments to make in your training as you get older.',
+    keywords: ['age stamina', 'stamina 30s 40s 50s', 'aging sexual health', 'stamina over time'],
+    category: 'problems',
+    priority: 0.6,
+    publishedAt: '2024-08-05T00:00:00Z',
+    updatedAt: '2024-10-22T00:00:00Z',
+  },
+  {
+    slug: 'medication-effects',
+    title: 'How Medications Affect Your Stamina',
+    description: 'Common medications that can affect stamina and what to discuss with your healthcare provider.',
+    keywords: ['medication stamina', 'drugs sexual health', 'prescription effects', 'medication side effects'],
+    category: 'problems',
+    priority: 0.6,
+    publishedAt: '2024-08-08T00:00:00Z',
+    updatedAt: '2024-10-15T00:00:00Z',
+  },
+
+  // ===== TOOLS & TECHNOLOGY =====
+  {
+    slug: 'using-stamina-timer-app',
+    title: 'How to Use the Stamina Timer App for Best Results',
+    description: 'Complete guide to getting the most out of the Stamina Timer app features for your training.',
+    keywords: ['stamina timer app', 'app guide', 'training app', 'how to use stamina timer'],
+    category: 'tools',
+    priority: 0.8,
+    publishedAt: '2024-08-12T00:00:00Z',
+    updatedAt: '2024-11-18T00:00:00Z',
+  },
+  {
+    slug: 'ai-coaching-benefits',
+    title: 'AI Coaching for Stamina: How It Works',
+    description: 'Learn how AI-powered coaching provides personalized recommendations for your stamina training.',
+    keywords: ['AI coaching', 'personalized training', 'smart coaching', 'AI recommendations'],
+    category: 'tools',
+    priority: 0.7,
+    publishedAt: '2024-08-15T00:00:00Z',
+    updatedAt: '2024-11-12T00:00:00Z',
+  },
+  {
+    slug: 'tracking-with-data',
+    title: 'Data-Driven Stamina Training: Using Analytics',
+    description: 'How to use training data and analytics to optimize your stamina training and see faster results.',
+    keywords: ['data training', 'analytics stamina', 'tracking progress', 'data-driven'],
+    category: 'tools',
+    priority: 0.7,
+    publishedAt: '2024-08-18T00:00:00Z',
+    updatedAt: '2024-11-05T00:00:00Z',
+  },
+  {
+    slug: 'setting-goals-app',
+    title: 'Setting Effective Goals in Your Stamina Training',
+    description: 'How to set SMART goals for your stamina training and use goal tracking for motivation.',
+    keywords: ['stamina goals', 'goal setting', 'training objectives', 'SMART goals stamina'],
+    category: 'tools',
+    priority: 0.6,
+    publishedAt: '2024-08-22T00:00:00Z',
+    updatedAt: '2024-10-28T00:00:00Z',
+  },
+
+  // ===== ADVANCED TOPICS =====
+  {
+    slug: 'tantric-techniques',
+    title: 'Tantric Techniques for Extended Stamina',
+    description: 'Ancient tantric practices adapted for modern stamina training - energy control and extended pleasure.',
+    keywords: ['tantric techniques', 'tantric stamina', 'energy control', 'tantric practices'],
+    category: 'advanced',
+    priority: 0.6,
+    publishedAt: '2024-08-25T00:00:00Z',
+    updatedAt: '2024-10-22T00:00:00Z',
+  },
+  {
+    slug: 'edging-marathon-training',
+    title: 'Marathon Edging: Advanced Endurance Training',
+    description: 'Advanced edging techniques for those seeking to dramatically extend their sessions and control.',
+    keywords: ['marathon edging', 'extended edging', 'long sessions', 'endurance training'],
+    category: 'advanced',
+    priority: 0.5,
+    publishedAt: '2024-08-28T00:00:00Z',
+    updatedAt: '2024-10-18T00:00:00Z',
+  },
+  {
+    slug: 'multiple-sessions',
+    title: 'Training for Multiple Sessions: Recovery and Stamina',
+    description: 'How to train for faster recovery and the ability to maintain stamina across multiple sessions.',
+    keywords: ['multiple sessions', 'recovery training', 'refractory period', 'session recovery'],
+    category: 'advanced',
+    priority: 0.5,
+    publishedAt: '2024-09-01T00:00:00Z',
+    updatedAt: '2024-10-15T00:00:00Z',
+  },
+  {
+    slug: 'biofeedback-training',
+    title: 'Biofeedback Techniques for Stamina Control',
+    description: 'Advanced biofeedback methods for gaining precise control over your body\'s responses.',
+    keywords: ['biofeedback stamina', 'body awareness', 'physiological control', 'advanced awareness'],
+    category: 'advanced',
+    priority: 0.5,
+    publishedAt: '2024-09-05T00:00:00Z',
+    updatedAt: '2024-10-12T00:00:00Z',
+  },
+] as const
+
+// =============================================================================
+// GUIDE CONTENT - Full content for each guide
+// =============================================================================
+
+export const GUIDE_CONTENT: Record<string, GuideContent> = {
+  'stamina-training-basics': {
+    readTime: '8 min read',
+    sections: [
+      {
+        title: 'What is Stamina Training?',
+        content: 'Stamina training is a systematic approach to improving your endurance and control during intimate moments. Unlike quick fixes or temporary solutions, stamina training focuses on building lasting improvements through consistent practice and proven techniques. The goal is to develop greater awareness of your body\'s responses and learn to regulate them effectively. This training combines physical exercises, mental techniques, and behavioral strategies that have been validated by research and clinical practice over decades.',
+      },
+      {
+        title: 'The Science Behind Stamina',
+        content: 'Your stamina is controlled by a complex interplay of physical and psychological factors. The pelvic floor muscles, nervous system responses, and mental state all play crucial roles. When you understand how arousal builds and how your body approaches the point of no return, you can learn to recognize these signals earlier and apply control techniques. Research shows that men who train consistently can significantly improve their average duration within just a few weeks of practice.',
+      },
+      {
+        title: 'Core Training Principles',
+        content: 'Effective stamina training follows several key principles: consistency over intensity, awareness before control, and progressive challenge. Start with basic exercises and gradually increase difficulty as you improve. The most important factor is regular practice - even 10-15 minutes a few times per week can lead to meaningful improvements. Track your sessions to identify patterns and measure progress objectively.',
+      },
+      {
+        title: 'Getting Started: Your First Week',
+        content: 'Begin your journey with awareness exercises. During your first week, focus on noticing your arousal levels on a scale of 1-10 without trying to change anything. This baseline awareness is crucial for all future training. Practice basic breathing techniques and learn to identify the sensations that indicate rising arousal. Don\'t rush - building this foundation properly will accelerate your progress in the weeks ahead.',
+      },
+    ],
+    tips: [
+      'Start with short 10-15 minute sessions and gradually increase duration',
+      'Track every session using the app to measure your progress objectively',
+      'Focus on consistency - 3-4 sessions per week is more effective than sporadic intensive training',
+      'Don\'t get discouraged by setbacks - they\'re a normal part of the learning process',
+      'Combine physical exercises with mental techniques for best results',
+    ],
+    relatedGuides: ['edging-techniques', 'start-stop-method', 'kegel-exercises-men', 'beginner-stamina-program'],
+  },
+
+  'edging-techniques': {
+    readTime: '10 min read',
+    sections: [
+      {
+        title: 'Understanding Edging',
+        content: 'Edging is a technique where you bring yourself close to climax and then pause or reduce stimulation to stay just below the threshold. This practice trains your body and mind to tolerate higher levels of arousal without reaching the point of no return. Over time, regular edging practice expands your capacity for sustained arousal and gives you greater control over your responses. It\'s one of the most effective techniques for building lasting stamina.',
+      },
+      {
+        title: 'The Arousal Scale',
+        content: 'To practice edging effectively, you need to understand and use the arousal scale. Rate your arousal from 1 (completely relaxed) to 10 (point of no return). Most beginners should practice staying between 7-8 on this scale. As you advance, you can practice going closer to 9 before backing off. The key is learning to recognize where you are on this scale and responding appropriately before it\'s too late.',
+      },
+      {
+        title: 'Step-by-Step Edging Practice',
+        content: 'Start by building arousal slowly until you reach about 7 on your scale. Pause all stimulation and take slow, deep breaths. Let your arousal drop to about 5 before resuming. Repeat this cycle multiple times during each session. Initially, aim for 3-5 cycles per session. As you improve, increase to 7-10 cycles. The pause duration will naturally decrease as you develop better control.',
+      },
+      {
+        title: 'Common Mistakes to Avoid',
+        content: 'The most common mistake is going too close to the edge too quickly. This leads to accidental finishes and can be frustrating. Always err on the side of caution, especially when starting out. Another mistake is not pausing long enough - give your arousal time to genuinely decrease before resuming. Finally, don\'t skip the breathing - it\'s a crucial part of regaining control during the pause.',
+      },
+    ],
+    tips: [
+      'Start conservatively - better to stop at 7 than accidentally cross the threshold',
+      'Use deep breathing during pauses to help lower arousal',
+      'Keep sessions to 15-20 minutes initially to maintain focus',
+      'Practice at times when you\'re relaxed and not rushed',
+      'Track the number of edges per session to measure improvement',
+    ],
+    relatedGuides: ['advanced-edging-techniques', 'start-stop-method', 'breathing-techniques-stamina', 'arousal-control-techniques'],
+  },
+
+  'kegel-exercises-men': {
+    readTime: '7 min read',
+    sections: [
+      {
+        title: 'What Are Kegel Exercises?',
+        content: 'Kegel exercises target the pelvic floor muscles - the same muscles you use to stop urination midstream or prevent passing gas. For men, strong pelvic floor muscles provide greater control over ejaculation and can significantly improve stamina. Originally developed for women, kegels have been proven equally effective for men seeking better sexual health and control.',
+      },
+      {
+        title: 'Finding Your Pelvic Floor Muscles',
+        content: 'Before you can exercise these muscles, you need to locate them. The easiest way is to stop your urine flow midstream - the muscles you use to do this are your pelvic floor muscles. Another method is to tighten the muscles that prevent you from passing gas. Once you\'ve identified these muscles, you can exercise them anytime, anywhere, without anyone knowing.',
+      },
+      {
+        title: 'Basic Kegel Exercise Routine',
+        content: 'Start with quick contractions: squeeze your pelvic floor muscles for 1-2 seconds, then release. Do 10 repetitions. Next, practice holds: squeeze and hold for 5 seconds, then release for 5 seconds. Do 10 repetitions. Perform this routine 3 times daily. As you get stronger, increase hold times to 10 seconds and add more repetitions.',
+      },
+      {
+        title: 'Integrating Kegels with Stamina Training',
+        content: 'Kegels become most powerful when combined with other techniques. During edging practice, a strong kegel contraction at high arousal levels can help you pull back from the edge. Some men find that relaxing the pelvic floor (reverse kegels) works better for them. Experiment to find what works for your body. The key is having conscious control over these muscles.',
+      },
+    ],
+    tips: [
+      'Practice finding your pelvic floor muscles before starting the exercises',
+      'Don\'t hold your breath while doing kegels - breathe normally',
+      'Start with the basic routine and progress gradually',
+      'Avoid doing kegels while urinating regularly as this can cause issues',
+      'Be patient - strength builds over 4-6 weeks of consistent practice',
+    ],
+    relatedGuides: ['reverse-kegels', 'how-to-do-kegels-correctly', 'pelvic-floor-strength-test', 'stamina-training-basics'],
+  },
+
+  'start-stop-method': {
+    readTime: '9 min read',
+    sections: [
+      {
+        title: 'Introduction to Start-Stop',
+        content: 'The start-stop method, also known as the stop-start technique, is one of the oldest and most researched approaches to building stamina. Developed by urologist James Semans in the 1950s, this technique has helped countless men gain control. The premise is simple: stimulate until you approach climax, stop completely until arousal subsides, then resume. This trains your body to tolerate extended periods of stimulation.',
+      },
+      {
+        title: 'How the Method Works',
+        content: 'The start-stop method works by repeatedly exposing you to high arousal states while preventing climax. Each time you stop before the point of no return and let arousal subside, you\'re teaching your nervous system that high arousal doesn\'t have to lead immediately to climax. Over time, this reconditioning effect allows you to maintain higher arousal levels for longer periods without losing control.',
+      },
+      {
+        title: 'Practicing the Technique',
+        content: 'Begin stimulation and pay close attention to your arousal levels. When you reach about 7-8 on a 10-point scale, stop all stimulation immediately. Don\'t try to "ride the edge" - stop cleanly. Wait until your arousal drops to about 3-4, which typically takes 30 seconds to a minute. Then resume stimulation. Repeat this cycle 4-5 times before allowing climax. Gradually increase the number of cycles as you improve.',
+      },
+      {
+        title: 'Advancing Your Practice',
+        content: 'As you become more proficient, challenge yourself by stopping closer to your point of no return and resuming stimulation sooner after stopping. You can also vary the intensity and speed of stimulation to build adaptability. Eventually, the goal is to maintain high arousal for extended periods with minimal need to stop. This progression typically takes several weeks to months of regular practice.',
+      },
+    ],
+    tips: [
+      'Stop earlier than you think you need to, especially when starting out',
+      'Use the complete stop - don\'t try to just slow down',
+      'Practice in a relaxed environment without time pressure',
+      'Combine with breathing techniques during the stop phase',
+      'Track your progress by counting cycles per session',
+    ],
+    relatedGuides: ['edging-techniques', 'squeeze-technique', 'arousal-control-techniques', 'point-of-no-return'],
+  },
+
+  'performance-anxiety-tips': {
+    readTime: '11 min read',
+    sections: [
+      {
+        title: 'Understanding Performance Anxiety',
+        content: 'Performance anxiety is the fear of not meeting expectations during intimate moments. This fear triggers your body\'s stress response, releasing cortisol and adrenaline that can directly interfere with your sexual response. The cruel irony is that worrying about performance often causes the very problems you\'re worried about. Understanding this cycle is the first step to breaking free from it.',
+      },
+      {
+        title: 'The Anxiety-Performance Cycle',
+        content: 'Performance anxiety creates a self-reinforcing cycle: anxiety leads to poor performance, which confirms your fears, which increases anxiety for the next time. Your brain starts associating intimate situations with stress rather than pleasure. Breaking this cycle requires addressing both the psychological patterns and the physical stress response. The good news is that this cycle can be reversed with the right approach.',
+      },
+      {
+        title: 'Cognitive Strategies',
+        content: 'Challenge negative thoughts by questioning their validity. Ask yourself: "Is this thought based on facts or fears?" Replace catastrophic thinking with realistic assessment. Instead of "This will be a disaster," try "I might feel nervous, but I can handle it." Practice self-compassion - everyone has off moments, and they don\'t define you. Focus on connection and pleasure rather than performance metrics.',
+      },
+      {
+        title: 'Physical Relaxation Techniques',
+        content: 'Your body can\'t be relaxed and anxious at the same time. Practice deep breathing: inhale for 4 counts, hold for 4, exhale for 6. This activates your parasympathetic nervous system and counteracts the stress response. Progressive muscle relaxation before intimate moments can also help. Regular exercise and adequate sleep build overall resilience against anxiety.',
+      },
+      {
+        title: 'Building Confidence Through Practice',
+        content: 'Confidence comes from positive experiences. Start by removing pressure - agree with your partner to have intimate time with no expectations of intercourse. Practice techniques solo where there\'s no performance pressure. Celebrate small wins and progress. Over time, positive experiences will gradually replace the anxious associations your brain has formed.',
+      },
+    ],
+    tips: [
+      'Talk to your partner about your feelings - shared vulnerability builds connection',
+      'Focus on sensations and pleasure rather than goals or outcomes',
+      'Practice relaxation techniques daily, not just before intimate moments',
+      'Consider professional help if anxiety significantly impacts your life',
+      'Remember that temporary difficulties are normal and don\'t define your worth',
+    ],
+    relatedGuides: ['mindfulness-for-stamina', 'confidence-building-exercises', 'stress-and-stamina', 'anxiety-induced-pe'],
+  },
+
+  'breathing-techniques-stamina': {
+    readTime: '8 min read',
+    sections: [
+      {
+        title: 'The Power of Breath',
+        content: 'Breathing is one of the most powerful tools you have for controlling arousal. Unlike your heart rate, which you can\'t directly control, your breath is under your conscious command. When you control your breath, you influence your entire nervous system, including the systems that govern arousal and sexual response. Proper breathing can be the difference between maintaining control and losing it.',
+      },
+      {
+        title: 'Diaphragmatic Breathing',
+        content: 'Most people breathe shallowly into their chest, especially when aroused or anxious. Diaphragmatic (belly) breathing engages your parasympathetic nervous system, promoting calm and control. Place one hand on your chest and one on your belly. Breathe so that your belly rises while your chest stays relatively still. This deeper breathing pattern is the foundation for all stamina-focused breathing techniques.',
+      },
+      {
+        title: 'The 4-7-8 Technique',
+        content: 'This technique is excellent for rapidly lowering arousal. Inhale quietly through your nose for 4 counts. Hold your breath for 7 counts. Exhale completely through your mouth for 8 counts. The extended exhale activates your relaxation response. Use this technique when you feel your arousal climbing too high, during pauses in edging practice, or anytime you need to regain control.',
+      },
+      {
+        title: 'Synchronized Breathing',
+        content: 'Practice synchronizing your breath with your movements or stimulation. Inhale as stimulation increases, exhale as it decreases. This creates a rhythm that keeps you present and aware. Some men find that exhaling during peak stimulation helps them stay below the threshold. Experiment to find what works best for your body.',
+      },
+    ],
+    tips: [
+      'Practice breathing techniques daily, even outside of training sessions',
+      'Start using breathing techniques at lower arousal levels before you need them urgently',
+      'Combine breathing with other techniques like kegels for greater effect',
+      'Don\'t hold your breath when aroused - keep breathing steadily',
+      'Make exhales longer than inhales to promote relaxation',
+    ],
+    relatedGuides: ['arousal-control-techniques', 'mindfulness-for-stamina', 'edging-techniques', 'yoga-for-stamina'],
+  },
+
+  'beginner-stamina-program': {
+    readTime: '12 min read',
+    sections: [
+      {
+        title: 'Program Overview',
+        content: 'This 30-day program is designed specifically for beginners who are new to structured stamina training. The program progresses from basic awareness exercises to practical control techniques. By the end of 30 days, you\'ll have established good training habits, developed foundational skills, and likely see measurable improvement. Commit to 15-20 minutes of training at least 4 days per week for best results.',
+      },
+      {
+        title: 'Week 1: Awareness Foundation',
+        content: 'The first week focuses entirely on awareness without trying to control anything. During solo sessions, practice rating your arousal on a 1-10 scale throughout. Notice how quickly arousal builds, what sensations precede high arousal, and how your body feels at different levels. Practice basic diaphragmatic breathing for 5 minutes daily. Start doing basic kegel exercises (3 sets of 10 reps) once daily.',
+      },
+      {
+        title: 'Week 2: Introduction to Control',
+        content: 'Begin the start-stop method. During sessions, stop when you reach 7 on your scale and wait until you drop to 4 before resuming. Aim for 3-4 stop cycles per session. Continue daily kegels, increasing hold time to 5 seconds. Practice the 4-7-8 breathing technique during your stop periods. Start tracking sessions in the app, noting duration and number of successful stops.',
+      },
+      {
+        title: 'Week 3: Building Control',
+        content: 'Increase to 5-6 stop cycles per session. Begin experimenting with edging - trying to stay at 7-8 for longer before stopping. Introduce reverse kegels and practice differentiating between contracting and relaxing your pelvic floor. Add 5 minutes of mindfulness meditation to your daily routine to build focus and body awareness.',
+      },
+      {
+        title: 'Week 4: Integration and Progression',
+        content: 'Combine all techniques: use breathing to manage arousal, kegels for control at high arousal, and the stop-start method as your framework. Push your edges closer to 8-9. Aim for 7-10 cycles per session. Review your tracking data to measure improvement. Plan your transition to the intermediate program based on your progress.',
+      },
+    ],
+    tips: [
+      'Don\'t skip Week 1 even if it feels basic - awareness is essential',
+      'Track every session in the app to see your progress objectively',
+      'If you\'re not seeing improvement, focus more on consistency rather than intensity',
+      'Rest days are important - don\'t train every day',
+      'Celebrate your progress, no matter how small it seems',
+    ],
+    relatedGuides: ['stamina-training-basics', 'start-stop-method', 'kegel-exercises-men', 'intermediate-stamina-program'],
+  },
+
+  'premature-ejaculation-guide': {
+    readTime: '14 min read',
+    sections: [
+      {
+        title: 'Understanding Premature Ejaculation',
+        content: 'Premature ejaculation (PE) is the most common sexual complaint among men, affecting about 30% of men at some point in their lives. PE is generally defined as ejaculation that occurs sooner than desired, causing distress. It\'s important to understand that PE exists on a spectrum and that most cases can be significantly improved through training. You\'re not broken - your reflexes are just responding faster than you\'d like.',
+      },
+      {
+        title: 'Types of PE: Lifelong vs Acquired',
+        content: 'Lifelong PE starts from your first sexual experiences and has always been present. It often has a biological component related to serotonin receptor sensitivity. Acquired PE develops after a period of normal function and is often related to psychological factors, relationship issues, or other health conditions. The type of PE you have may influence which approaches work best, but both respond to behavioral training.',
+      },
+      {
+        title: 'Causes and Contributing Factors',
+        content: 'PE is usually caused by a combination of factors. Biological factors include nervous system sensitivity, hormonal variations, and genetics. Psychological factors include anxiety, early sexual experiences, relationship stress, and negative thought patterns. Lifestyle factors like stress, lack of sleep, and poor fitness can also contribute. Most men have multiple contributing factors.',
+      },
+      {
+        title: 'The Training Approach',
+        content: 'Behavioral techniques are the first-line treatment for PE because they\'re safe, effective, and address the root causes. The core techniques include the start-stop method, edging, kegel exercises, and arousal awareness training. These techniques work by retraining your body\'s responses and building your ability to tolerate and manage arousal. Most men see significant improvement within 4-8 weeks of consistent practice.',
+      },
+      {
+        title: 'Complementary Strategies',
+        content: 'Beyond direct training, several strategies can help. Address performance anxiety using cognitive techniques. Strengthen your relationship communication. Optimize lifestyle factors like sleep, stress, and fitness. Consider extended foreplay as part of your intimate encounters. Some men benefit from medical options as a bridge while developing control through training. Consult a healthcare provider if training alone isn\'t sufficient.',
+      },
+    ],
+    tips: [
+      'PE is extremely common and highly treatable - you\'re not alone',
+      'Focus on the training approach before considering medications',
+      'Address psychological factors alongside physical training',
+      'Be patient - meaningful change takes weeks, not days',
+      'Partner involvement and communication significantly improve outcomes',
+    ],
+    relatedGuides: ['anxiety-induced-pe', 'start-stop-method', 'sensitivity-issues', 'communicating-with-partner'],
+  },
+
+  'what-is-stamina-training': {
+    readTime: '7 min read',
+    sections: [
+      {
+        title: 'Defining Stamina Training',
+        content: 'Stamina training refers to a systematic set of exercises and techniques designed to improve your endurance, control, and overall performance during intimate activities. Unlike pills or quick fixes that offer temporary solutions, stamina training creates lasting changes in how your body and mind respond to arousal. Think of it like training for any other physical skill - with practice, you build capability that stays with you.',
+      },
+      {
+        title: 'How Stamina Training Works',
+        content: 'Your stamina is influenced by both your physical responses and your mental state. Stamina training works on both fronts. Physically, exercises like kegels strengthen the muscles involved in ejaculatory control. Behaviorally, techniques like edging train your nervous system to tolerate higher arousal levels. Mentally, awareness and relaxation practices reduce anxiety and increase control. Together, these approaches create comprehensive improvement.',
+      },
+      {
+        title: 'The Benefits Beyond Duration',
+        content: 'While lasting longer is the primary goal, stamina training offers many additional benefits. Men who train report greater confidence, reduced performance anxiety, better body awareness, and more satisfying intimate experiences overall. Partners often notice the difference too - when you\'re not worried about finishing too quickly, you can be more present and connected. These secondary benefits often prove as valuable as the duration improvements.',
+      },
+      {
+        title: 'Who Can Benefit',
+        content: 'Stamina training benefits any man who wants more control over his responses, whether he has specific concerns about duration or simply wants to enhance his capabilities. Men with premature ejaculation see the most dramatic improvements, but even those with average stamina can develop greater control and endurance. There\'s no minimum or maximum age - the techniques work across the lifespan.',
+      },
+    ],
+    tips: [
+      'Stamina training is a learnable skill, not an innate ability',
+      'Consistent practice is more important than intensive sessions',
+      'Most men see improvement within 2-4 weeks of regular training',
+      'The techniques are safe and have no negative side effects',
+      'Benefits extend beyond just lasting longer to overall intimate wellness',
+    ],
+    relatedGuides: ['stamina-training-basics', 'how-long-to-see-results', 'science-of-stamina', 'beginner-stamina-program'],
+  },
+
+  'squeeze-technique': {
+    readTime: '8 min read',
+    sections: [
+      {
+        title: 'History of the Squeeze Technique',
+        content: 'The squeeze technique was developed by pioneering sex researchers William Masters and Virginia Johnson in the 1960s. It has been clinically studied and proven effective for improving ejaculatory control. The technique involves applying pressure to the penis at a specific point when approaching climax, which temporarily reduces arousal and prevents ejaculation. It remains one of the most established behavioral treatments for premature ejaculation.',
+      },
+      {
+        title: 'How to Perform the Squeeze',
+        content: 'When you feel you\'re approaching the point of no return, stop stimulation and apply firm pressure to the area where the head meets the shaft. Use your thumb on the underside (frenulum area) and first two fingers on top. Squeeze firmly for about 10-20 seconds until the urge to ejaculate passes. Your erection may decrease slightly - this is normal. Once the urge subsides, wait about 30 seconds before resuming stimulation.',
+      },
+      {
+        title: 'Practicing Effectively',
+        content: 'Begin by practicing solo so you can focus on learning the technique without pressure. Use the squeeze 3-4 times per session before allowing yourself to finish. Pay attention to the timing - you need to apply the squeeze before passing the point of no return for it to work. The technique requires practice to get the timing and pressure right, so be patient with yourself as you learn.',
+      },
+      {
+        title: 'Integrating with Partner',
+        content: 'Once you\'re comfortable with the technique, it can be used during partnered activities. Communication is key - you\'ll need to signal when you need a pause. Your partner can apply the squeeze, or you can do it yourself. Some couples find this becomes a natural part of their intimate rhythm. Over time, the need for squeezing decreases as you develop better internal control.',
+      },
+    ],
+    tips: [
+      'Practice solo first to learn proper timing and pressure',
+      'The squeeze should be firm but not painful',
+      'Apply the squeeze before you reach the point of no return',
+      'It\'s normal for your erection to slightly decrease - it will return',
+      'Combine with breathing techniques during the squeeze for better effect',
+    ],
+    relatedGuides: ['start-stop-method', 'point-of-no-return', 'edging-techniques', 'partner-exercises'],
+  },
+
+  'daily-stamina-routine': {
+    readTime: '9 min read',
+    sections: [
+      {
+        title: 'Why Routine Matters',
+        content: 'Consistency is the single most important factor in stamina improvement. A daily routine, even a brief one, keeps your training on track and accelerates results. Your body and mind respond to regular practice by adapting and improving. Just as athletes train daily, stamina improvement requires regular engagement. A well-designed routine makes training automatic rather than something you have to constantly motivate yourself to do.',
+      },
+      {
+        title: 'Morning Practice (5-10 minutes)',
+        content: 'Start your day with kegel exercises - 3 sets of 10 contractions with 5-second holds. Follow with 3 minutes of diaphragmatic breathing while still in bed or sitting comfortably. This morning routine strengthens your physical foundation and sets a mindful tone for the day. These exercises can be done before getting out of bed, making them easy to integrate into your existing morning routine.',
+      },
+      {
+        title: 'Midday Check-in (2-3 minutes)',
+        content: 'Take a brief break to practice body awareness. Close your eyes and scan your body from head to toe. Notice any tension, especially in your pelvic region, and consciously relax. Do a quick set of kegels. This midday practice maintains your mind-body connection throughout the day and reinforces the awareness skills crucial for control.',
+      },
+      {
+        title: 'Evening Training Session (15-20 minutes)',
+        content: 'Your main training happens in the evening. Practice your primary technique (start-stop, edging, or whatever you\'re currently focusing on) for 15-20 minutes. Use the Stamina Timer app to track your session. End with 2-3 minutes of cool-down breathing. On rest days, replace this with 10 minutes of mindfulness meditation focused on body sensations.',
+      },
+      {
+        title: 'Weekly Schedule Structure',
+        content: 'Train 4-5 days per week with 2-3 rest days. Rest days are important for recovery and preventing fatigue. A sample week: train Monday, Tuesday, rest Wednesday, train Thursday, Friday, rest Saturday, train Sunday. Adjust based on your lifestyle. The key is establishing a consistent pattern that you can maintain long-term.',
+      },
+    ],
+    tips: [
+      'Link your routine to existing habits (morning kegels right after waking)',
+      'Set reminders on your phone until the routine becomes automatic',
+      'Don\'t skip rest days - they\'re part of the training',
+      'If you miss a session, just continue with your routine - don\'t try to make it up',
+      'Review and adjust your routine monthly based on your progress',
+    ],
+    relatedGuides: ['5-minute-stamina-routine', 'morning-stamina-routine', 'weekly-training-schedule', 'beginner-stamina-program'],
+  },
+}
+
+// =============================================================================
+// CATEGORY DEFINITIONS
+// =============================================================================
+
+export const EXPANDED_CATEGORIES = {
+  fundamentals: {
+    id: 'fundamentals',
+    title: 'Fundamentals',
+    description: 'Core concepts and basics of stamina training for beginners',
+    slug: 'fundamentals',
+    keywords: ['stamina basics', 'beginner guide', 'getting started', 'fundamentals'],
+    priority: 0.9,
+  },
+  techniques: {
+    id: 'techniques',
+    title: 'Techniques',
+    description: 'Proven methods and techniques for building stamina and control',
+    slug: 'techniques',
+    keywords: ['techniques', 'methods', 'exercises', 'practices'],
+    priority: 0.9,
+  },
+  exercises: {
+    id: 'exercises',
+    title: 'Exercises',
+    description: 'Physical exercises to strengthen control and improve stamina',
+    slug: 'exercises',
+    keywords: ['exercises', 'workouts', 'physical training', 'kegels'],
+    priority: 0.8,
+  },
+  mental: {
+    id: 'mental',
+    title: 'Mental Training',
+    description: 'Mindset and psychological strategies for better performance',
+    slug: 'mental',
+    keywords: ['mental training', 'psychology', 'mindset', 'confidence'],
+    priority: 0.8,
+  },
+  routines: {
+    id: 'routines',
+    title: 'Training Routines',
+    description: 'Structured programs and daily routines for consistent improvement',
+    slug: 'routines',
+    keywords: ['routines', 'programs', 'schedules', 'plans'],
+    priority: 0.8,
+  },
+  lifestyle: {
+    id: 'lifestyle',
+    title: 'Lifestyle',
+    description: 'Diet, sleep, exercise, and lifestyle factors that affect stamina',
+    slug: 'lifestyle',
+    keywords: ['lifestyle', 'diet', 'sleep', 'health'],
+    priority: 0.7,
+  },
+  relationships: {
+    id: 'relationships',
+    title: 'Relationships',
+    description: 'Partner communication and relationship aspects of stamina training',
+    slug: 'relationships',
+    keywords: ['relationships', 'partner', 'communication', 'couples'],
+    priority: 0.7,
+  },
+  science: {
+    id: 'science',
+    title: 'Science & Education',
+    description: 'Scientific research and education about stamina and arousal',
+    slug: 'science',
+    keywords: ['science', 'research', 'education', 'physiology'],
+    priority: 0.7,
+  },
+  problems: {
+    id: 'problems',
+    title: 'Common Issues',
+    description: 'Solutions for specific problems like PE and anxiety',
+    slug: 'problems',
+    keywords: ['problems', 'issues', 'solutions', 'PE'],
+    priority: 0.8,
+  },
+  tools: {
+    id: 'tools',
+    title: 'Tools & Technology',
+    description: 'Using apps and technology for more effective training',
+    slug: 'tools',
+    keywords: ['tools', 'apps', 'technology', 'tracking'],
+    priority: 0.7,
+  },
+  advanced: {
+    id: 'advanced',
+    title: 'Advanced Topics',
+    description: 'Advanced techniques for experienced practitioners',
+    slug: 'advanced',
+    keywords: ['advanced', 'expert', 'mastery', 'pro'],
+    priority: 0.6,
+  },
+} as const
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+export function getGuideBySlug(slug: string) {
+  const topic = EXPANDED_GUIDE_TOPICS.find(g => g.slug === slug)
+  const content = GUIDE_CONTENT[slug]
+  if (!topic) return null
+  return { ...topic, content }
+}
+
+export function getGuidesByCategory(category: string) {
+  return EXPANDED_GUIDE_TOPICS.filter(g => g.category === category)
+}
+
+export function getFeaturedGuides() {
+  return EXPANDED_GUIDE_TOPICS.filter(g => 'featured' in g && g.featured)
+}
+
+export function getAllGuideSlugs() {
+  return EXPANDED_GUIDE_TOPICS.map(g => g.slug)
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -131,9 +131,10 @@ export async function middleware(req: NextRequest) {
   } = await supabase.auth.getUser()
 
   // Public routes that don't require authentication
-  const publicRoutes = ['/', '/login', '/license', '/privacy', '/terms', '/auth/callback']
+  const publicRoutes = ['/', '/login', '/license', '/privacy', '/terms', '/auth/callback', '/faq', '/guides']
   const isPublicRoute = publicRoutes.includes(pathname) ||
                         pathname.startsWith('/share/') ||
+                        pathname.startsWith('/guides/') ||
                         pathname === '/offline.html' ||
                         isApiRoute
 


### PR DESCRIPTION
- Add 66+ guide topics across 11 categories (fundamentals, techniques, exercises, mental, routines, lifestyle, relationships, science, problems, tools, advanced)
- Make /guides and /faq routes public (no login required)
- Add guides link to homepage navbar and app navigation
- Create guides-data.ts with full content for key guides and default content generator for others
- Update sitemap to include all guide pages with proper priorities
- Add featured guides section and category navigation on guides hub
- Implement cross-category internal linking for better SEO
- Add table of contents and "You Might Also Like" sections to guides