### PR TITLE
Fix security vulnerabilities in jspdf and tar

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.29.0",
-    "jspdf": "^4.0.0",
+    "jspdf": "^4.1.0",
     "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.562.0",
     "next": "^16.1.5",
@@ -84,6 +84,9 @@
     "vitest": "^4.0.17"
   },
   "packageManager": "yarn@4.9.4",
+  "resolutions": {
+    "tar": "^7.5.7"
+  },
   "browserslist": [
     "last 2 Chrome versions",
     "last 2 Firefox versions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,7 +3972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.4":
+"dompurify@npm:^3.3.1":
   version: 3.3.1
   resolution: "dompurify@npm:3.3.1"
   dependencies:
@@ -5660,14 +5660,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jspdf@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jspdf@npm:4.0.0"
+"jspdf@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "jspdf@npm:4.1.0"
   dependencies:
     "@babel/runtime": "npm:^7.28.4"
     canvg: "npm:^3.0.11"
     core-js: "npm:^3.6.0"
-    dompurify: "npm:^3.2.4"
+    dompurify: "npm:^3.3.1"
     fast-png: "npm:^6.2.0"
     fflate: "npm:^0.8.1"
     html2canvas: "npm:^1.0.0-rc.5"
@@ -5680,7 +5680,7 @@ __metadata:
       optional: true
     html2canvas:
       optional: true
-  checksum: 10c0/042fef72dd71353bbe5ba57c8a7bbadfd62bdcdf33f5a81276fd4c66034cb43fe112b04940d02c7d31402fa645390312a5bc854ea4a179f71257ed6d2dec75e8
+  checksum: 10c0/1565c6e01ebd7c9414be6c286d4b1ce7f7d511c81efa49b9a0835a5479e7927003b08d71b5e892a046fcfa2b8b438d19703d08c4c1a2b8074f5c965495371090
   languageName: node
   linkType: hard
 
@@ -8016,7 +8016,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^7.0.1"
     framer-motion: "npm:^12.29.0"
     jsdom: "npm:^27.4.0"
-    jspdf: "npm:^4.0.0"
+    jspdf: "npm:^4.1.0"
     jspdf-autotable: "npm:^5.0.7"
     lucide-react: "npm:^0.562.0"
     next: "npm:^16.1.5"
@@ -8265,16 +8265,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.2":
-  version: 7.5.6
-  resolution: "tar@npm:7.5.6"
+"tar@npm:^7.5.7":
+  version: 7.5.7
+  resolution: "tar@npm:7.5.7"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/08af3807035957650ad5f2a300c49ca4fe0566ac0ea5a23741a5b5103c6da42891a9eeaed39bc1fbcf21c5cac4dc846828a004727fb08b9d946322d3144d1fd2
+  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Security fixes for CVEs identified by OSV scanner:

1. jspdf 4.0.0 → 4.1.0 (4 vulnerabilities):
   - Cross-User Data Leakage via shared variable in addJS method
   - Stored XMP Metadata Injection (Spoofing & Integrity Violation)
   - PDF Injection in AcroFormChoiceField (Arbitrary JavaScript Execution)
   - DoS via Unvalidated BMP Dimensions in BMPDecoder

2. tar 7.5.6 → 7.5.7 (CVE-2026-24842 / GHSA-34x7-hfp2-rc4v):
   - Arbitrary File Creation/Overwrite via Hardlink Path Traversal
   - Added yarn resolutions to force transitive dependency upgrade

Build, typecheck, and lint all pass.